### PR TITLE
Added LLM service using OpenRouter

### DIFF
--- a/chat_test.py
+++ b/chat_test.py
@@ -1,0 +1,44 @@
+"""Quick interactive chat test — run directly with: python chat_test.py"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, "src")
+
+# Load .env
+with open(".env") as f:
+    for line in f:
+        line = line.strip()
+        if line and "=" in line:
+            k, v = line.split("=", 1)
+            os.environ[k] = v.strip('"')
+
+from miminions.agent import create_minion
+from miminions.memory.distiller import llm_filter
+
+
+async def chat():
+    minion = create_minion(
+        name="MiMinions",
+        description=llm_filter()["history_summary"],
+    )
+    history = []
+    print("MiMinions ready. Type 'exit' to quit.\n")
+
+    while True:
+        try:
+            msg = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nBye.")
+            break
+
+        if not msg or msg.lower() == "exit":
+            break
+
+        reply = await minion.run(msg, message_history=history)
+        history = minion._last_messages
+        print(f"\n{reply}\n")
+
+
+asyncio.run(chat())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "click>=8.0.0",
     "pydantic>=2.0.0",
     "pydantic-ai>=0.1.0",
+    "openai>=1.0.0",
     "mcp>=1.23.0",
     "numpy>=1.21.0",
     "pdfplumber>=0.9.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies
 pydantic>=2.0.0
 pydantic-ai>=0.1.0
+openai>=1.0.0
 mcp>=1.0.0
 sentence-transformers>=2.2.0
 numpy>=1.21.0

--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -2,12 +2,14 @@
 
 import asyncio
 import inspect
+import os
 import time
 from typing import Any, Callable, Dict, List, Optional
 from pathlib import Path
 
 from pydantic_ai import Agent, Tool, RunContext
-from pydantic_ai.models.test import TestModel
+from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.providers.openai import OpenAIProvider
 from mcp import StdioServerParameters
 
 from ..tools import GenericTool
@@ -87,8 +89,27 @@ class Minion:
         self._connected_servers: Dict[str, StdioServerParameters] = {}
         self._chunker = TextChunker(chunk_size=chunk_size, overlap=overlap)
         
-        # Replace TestModel with real model for LLM support
-        self._model = model or TestModel()
+        # ------------------------------------------------------------------
+        # Model selection
+        # ------------------------------------------------------------------
+        # Build the default OpenRouter-backed model when no model is supplied.
+        # OpenRouter speaks the OpenAI wire protocol; we point OpenAIProvider
+        # at their base URL and hand it the OPENROUTER_API_KEY from the env.
+        # The model string uses the free-tier suffix (:free) to avoid burning
+        # credits during development.
+        if model is not None:
+            self._model = model
+        else:
+            api_key = os.environ.get("OPENROUTER_API_KEY", "")
+            provider = OpenAIProvider(
+                base_url="https://openrouter.ai/api/v1",
+                api_key=api_key,
+            )
+            self._model = OpenAIModel(
+                "openai/gpt-oss-20b:free",
+                provider=provider,
+            )
+
         self._pydantic_ai_agent: Optional[Agent] = None
         self._pydantic_ai_tools: List[Tool] = []
         

--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -66,11 +66,17 @@ class RegisteredTool:
 
 class Minion:
     """
-    Minion agent implementation.
-    
-    Uses pydantic_ai infrastructure for LLM-ready tool management.
-    Currently operates in direct execution mode (no LLM) but structured
-    for easy LLM integration by replacing TestModel with a real model.
+    Minion — an LLM-powered agent built on top of pydantic_ai.
+
+    Minion owns the full agent lifecycle: model config, tool registry, and the
+    async reasoning loop.  Callers interact only with Minion — the underlying
+    pydantic_ai Agent is a private implementation detail.
+
+    Typical usage::
+
+        minion = create_minion(name="MyAgent", description="...")
+        minion.register_tool("do_thing", "Does a thing", do_thing)
+        reply = await minion.run("Please do the thing")
     """
 
     def __init__(
@@ -414,10 +420,31 @@ class Minion:
         if rebuild:
             self._rebuild_pydantic_ai_agent()
 
-    def get_pydantic_ai_agent(self) -> Agent:
-        """Get the underlying pydantic_ai Agent for LLM operations. Use for when integrating with an LLM."""
+    async def run(self, prompt: str, message_history: Optional[List[Any]] = None) -> str:
+        """Send a prompt to the LLM and return the reply.
+
+        This is the primary entry point for agent interaction.  Tools registered
+        via ``register_tool`` are automatically available to the LLM and will be
+        called by pydantic_ai whenever the model decides to use them.
+
+        Args:
+            prompt: The user message to send.
+            message_history: Optional prior messages (pydantic_ai message objects)
+                             for multi-turn conversation context.
+
+        Returns:
+            The LLM's reply as a plain string.
+
+        Raises:
+            Exception: Re-raises any network / API error so callers can handle it.
+        """
         self._rebuild_pydantic_ai_agent()
-        return self._pydantic_ai_agent
+        result = await self._pydantic_ai_agent.run(
+            prompt,
+            message_history=message_history or None,
+        )
+        self._last_messages = result.all_messages()
+        return result.output if hasattr(result, "output") else str(result.data)
 
     def set_model(self, model: Any) -> None:
         self._model = model

--- a/src/miminions/interface/cli/chat.py
+++ b/src/miminions/interface/cli/chat.py
@@ -1,4 +1,4 @@
-"""Async chat CLI — talks to the live OpenRouter LLM via pydantic_ai."""
+"""Interactive chat CLI — user messages go to the Minion, replies come back."""
 
 from __future__ import annotations
 
@@ -15,70 +15,20 @@ from miminions.core.workspace import WorkspaceManager
 from miminions.interface.cli.auth import get_config_dir
 
 
-# ---------------------------------------------------------------------------
-# Workspace helpers (unchanged)
-# ---------------------------------------------------------------------------
-
-
 def _resolve_workspace(manager: Any, workspace_ref: str) -> Any:
     workspaces = manager.load_workspaces()
     if not workspaces:
         return None
     if workspace_ref in workspaces:
         return workspaces[workspace_ref]
-    for workspace_id, workspace in workspaces.items():
-        if str(workspace_id) == workspace_ref:
+    for ws_id, workspace in workspaces.items():
+        if str(ws_id) == workspace_ref:
             return workspace
-        if getattr(workspace, "id", None) is not None and str(workspace.id) == workspace_ref:
+        if str(getattr(workspace, "id", "")) == workspace_ref:
             return workspace
-        if getattr(workspace, "name", None) is not None and str(workspace.name) == workspace_ref:
+        if str(getattr(workspace, "name", "")) == workspace_ref:
             return workspace
     return None
-
-
-# ---------------------------------------------------------------------------
-# Agent runner
-# ---------------------------------------------------------------------------
-
-
-async def _run_agent(user_text: str, message_history: list[Any]) -> str:
-    """Run one turn of the LLM agent and return the reply text."""
-    # Pull the base identity prompt from the stub distiller.
-    stub = llm_filter()
-    system_desc = stub.get("history_summary", "You are MiMinions, a helpful AI assistant.")
-
-    minion = create_minion(name="MiMinions", description=system_desc)
-
-    # --- Register tools the LLM can call ---
-    def list_registered_tools() -> list[str]:
-        """Return the names of all tools registered on this agent."""
-        return minion.list_tools()
-
-    minion.register_tool(
-        name="list_registered_tools",
-        description="List all tool names currently registered on the agent.",
-        func=list_registered_tools,
-    )
-
-    pydantic_agent = minion.get_pydantic_ai_agent()
-
-    try:
-        result = await pydantic_agent.run(
-            user_text,
-            message_history=message_history or None,
-        )
-        return result.output if hasattr(result, "output") else str(result.data)
-    except Exception as exc:
-        error_type = type(exc).__name__
-        click.echo(f"\n[agent-error] {error_type}: {exc}", err=True)
-        return (
-            f"[agent-error] {error_type} — check your OPENROUTER_API_KEY and try again."
-        )
-
-
-# ---------------------------------------------------------------------------
-# CLI
-# ---------------------------------------------------------------------------
 
 
 @click.group()
@@ -91,11 +41,12 @@ def chat_cli():
 @click.option("--workspace", "workspace_ref", required=True, help="Workspace id or name.")
 @click.option("--session", "session_id", default=None, help="Optional existing session id.")
 def chat_command(workspace_ref: str, session_id: str | None) -> None:
-    """Start an interactive chat session (LLM-powered via OpenRouter)."""
-    asyncio.run(_async_chat(workspace_ref, session_id))
+    """Start an interactive chat session powered by the Minion agent."""
+    asyncio.run(_chat_loop(workspace_ref, session_id))
 
 
-async def _async_chat(workspace_ref: str, session_id: str | None) -> None:
+async def _chat_loop(workspace_ref: str, session_id: str | None) -> None:
+    """Main async chat loop."""
     manager = WorkspaceManager(get_config_dir())
     workspace = _resolve_workspace(manager, workspace_ref)
 
@@ -108,38 +59,45 @@ async def _async_chat(workspace_ref: str, session_id: str | None) -> None:
 
     root = Path(root_path)
     if not root.exists():
-        raise click.ClickException(f"Workspace root_path does not exist: {root}")
+        raise click.ClickException(f"root_path does not exist: {root}")
 
     store = JsonlSessionStore(root)
     if not session_id:
         session_id = store.create_session_id()
 
-    workspace_name = getattr(workspace, "name", getattr(workspace, "id", "unknown"))
-    click.echo(f"Workspace : {workspace_name}")
-    click.echo(f"Session   : {session_id}")
-    click.echo("Model     : openai/gpt-oss-20b:free (OpenRouter)")
-    click.echo("Type 'exit' or 'quit' to stop.")
-    click.echo("")
+    # Build the agent once — it lives for the entire session.
+    system_prompt = llm_filter()["history_summary"]
+    minion = create_minion(name="MiMinions", description=system_prompt)
 
+    workspace_name = getattr(workspace, "name", getattr(workspace, "id", "unknown"))
+    click.echo(f"Workspace : {workspace_name}  |  Session: {session_id}")
+    click.echo("Model     : openai/gpt-oss-20b:free via OpenRouter")
+    click.echo("Type 'exit' or 'quit' to end the session.\n")
+
+    # Accumulated pydantic_ai message objects — gives the LLM conversation memory.
     message_history: list[Any] = []
 
     while True:
         try:
             user_text = input("> ").strip()
         except (EOFError, KeyboardInterrupt):
-            click.echo("\nExiting chat.")
+            click.echo("\nSession ended.")
             break
 
         if not user_text:
             continue
         if user_text.lower() in {"exit", "quit"}:
-            click.echo("Exiting chat.")
+            click.echo("Session ended.")
             break
 
         store.append(session_id, "user", user_text, meta={"source": "cli-chat"})
-        click.echo("  (thinking…)")
 
-        reply = await _run_agent(user_text, message_history)
+        try:
+            reply = await minion.run(user_text, message_history=message_history)
+            # Keep the full message history so the LLM remembers prior turns.
+            message_history = minion._last_messages
+        except Exception as exc:
+            reply = f"[error] {type(exc).__name__}: {exc}"
 
         store.append(session_id, "assistant", reply, meta={"source": "cli-chat"})
         click.echo(f"\n{reply}\n")

--- a/src/miminions/interface/cli/chat.py
+++ b/src/miminions/interface/cli/chat.py
@@ -1,115 +1,101 @@
+"""Async chat CLI — talks to the live OpenRouter LLM via pydantic_ai."""
+
 from __future__ import annotations
 
-import json
+import asyncio
 from pathlib import Path
 from typing import Any
 
 import click
 
-from miminions.agent.context_builder import ContextBuilder
+from miminions.agent import create_minion
+from miminions.memory.distiller import llm_filter
 from miminions.session.store import JsonlSessionStore
 from miminions.core.workspace import WorkspaceManager
 from miminions.interface.cli.auth import get_config_dir
 
 
-def _resolve_workspace(manager: Any, workspace_ref: str) -> Any:
-    """Resolve a workspace by id or name using WorkspaceManager.load_workspaces()."""
-    workspaces = manager.load_workspaces()
+# ---------------------------------------------------------------------------
+# Workspace helpers (unchanged)
+# ---------------------------------------------------------------------------
 
+
+def _resolve_workspace(manager: Any, workspace_ref: str) -> Any:
+    workspaces = manager.load_workspaces()
     if not workspaces:
         return None
-
-    # Ttry exact dict key match
     if workspace_ref in workspaces:
         return workspaces[workspace_ref]
-
-    # Try matching against workspace.id or workspace.name
     for workspace_id, workspace in workspaces.items():
         if str(workspace_id) == workspace_ref:
             return workspace
-
         if getattr(workspace, "id", None) is not None and str(workspace.id) == workspace_ref:
             return workspace
-
         if getattr(workspace, "name", None) is not None and str(workspace.name) == workspace_ref:
             return workspace
-
     return None
 
 
-def _save_manager(manager: Any) -> None:
-    """Persist manager state if a save-like method exists."""
-    for method_name in ("save", "save_workspaces", "persist"):
-        if hasattr(manager, method_name):
-            getattr(manager, method_name)()
-            return
+# ---------------------------------------------------------------------------
+# Agent runner
+# ---------------------------------------------------------------------------
 
 
-def _default_agent_reply(
-    user_text: str,
-    context: str,
-    workspace: Any,
-    session_id: str,
-) -> str:
-    """Fallback reply used until the real agent hook is wired in."""
-    workspace_name = getattr(workspace, "name", None) or getattr(workspace, "id", "unknown")
-    preview = context[:500].strip()
+async def _run_agent(user_text: str, message_history: list[Any]) -> str:
+    """Run one turn of the LLM agent and return the reply text."""
+    # Pull the base identity prompt from the stub distiller.
+    stub = llm_filter()
+    system_desc = stub.get("history_summary", "You are MiMinions, a helpful AI assistant.")
 
-    return (
-        f"[demo-reply] workspace={workspace_name} session={session_id}\n\n"
-        f"You said: {user_text}\n\n"
-        f"Context preview:\n{preview}"
+    minion = create_minion(name="MiMinions", description=system_desc)
+
+    # --- Register tools the LLM can call ---
+    def list_registered_tools() -> list[str]:
+        """Return the names of all tools registered on this agent."""
+        return minion.list_tools()
+
+    minion.register_tool(
+        name="list_registered_tools",
+        description="List all tool names currently registered on the agent.",
+        func=list_registered_tools,
     )
 
+    pydantic_agent = minion.get_pydantic_ai_agent()
 
-def _run_agent(
-    user_text: str,
-    context: str,
-    workspace: Any,
-    session_id: str,
-) -> str:
-    """Run the agent for one user message.
-
-    Current behavior:
-    1. If the workspace has a callable 'chat_handler', use it.
-    2. Otherwise fall back to a demo reply.
-
-    This keeps the CLI usable now while letting you wire in the real
-    agent implementation later.
-    """
-    chat_handler = getattr(workspace, "chat_handler", None)
-    if callable(chat_handler):
-        return str(
-            chat_handler(
-                user_text=user_text,
-                context=context,
-                workspace=workspace,
-                session_id=session_id,
-            )
+    try:
+        result = await pydantic_agent.run(
+            user_text,
+            message_history=message_history or None,
+        )
+        return result.output if hasattr(result, "output") else str(result.data)
+    except Exception as exc:
+        error_type = type(exc).__name__
+        click.echo(f"\n[agent-error] {error_type}: {exc}", err=True)
+        return (
+            f"[agent-error] {error_type} — check your OPENROUTER_API_KEY and try again."
         )
 
-    return _default_agent_reply(user_text, context, workspace, session_id)  
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
 
 @click.group()
 def chat_cli():
     """Chat commands."""
     pass
 
+
 @chat_cli.command("start")
-@click.option(
-    "--workspace",
-    "workspace_ref",
-    required=True,
-    help="Workspace id or name.",
-)
-@click.option(
-    "--session",
-    "session_id",
-    default=None,
-    help="Optional existing session id.",
-)
+@click.option("--workspace", "workspace_ref", required=True, help="Workspace id or name.")
+@click.option("--session", "session_id", default=None, help="Optional existing session id.")
 def chat_command(workspace_ref: str, session_id: str | None) -> None:
-    """Start an interactive chat session for a workspace."""
+    """Start an interactive chat session (LLM-powered via OpenRouter)."""
+    asyncio.run(_async_chat(workspace_ref, session_id))
+
+
+async def _async_chat(workspace_ref: str, session_id: str | None) -> None:
     manager = WorkspaceManager(get_config_dir())
     workspace = _resolve_workspace(manager, workspace_ref)
 
@@ -118,24 +104,24 @@ def chat_command(workspace_ref: str, session_id: str | None) -> None:
 
     root_path = getattr(workspace, "root_path", None)
     if not root_path:
-        raise click.ClickException(
-            "This workspace has no root_path yet. Run workspace init-files first."
-        )
+        raise click.ClickException("This workspace has no root_path. Run workspace init-files first.")
 
     root = Path(root_path)
     if not root.exists():
         raise click.ClickException(f"Workspace root_path does not exist: {root}")
 
-    context = ContextBuilder().build(workspace, root)
     store = JsonlSessionStore(root)
-
     if not session_id:
         session_id = store.create_session_id()
 
-    click.echo(f"Workspace: {getattr(workspace, 'name', getattr(workspace, 'id', 'unknown'))}")
-    click.echo(f"Session: {session_id}")
+    workspace_name = getattr(workspace, "name", getattr(workspace, "id", "unknown"))
+    click.echo(f"Workspace : {workspace_name}")
+    click.echo(f"Session   : {session_id}")
+    click.echo("Model     : openai/gpt-oss-20b:free (OpenRouter)")
     click.echo("Type 'exit' or 'quit' to stop.")
     click.echo("")
+
+    message_history: list[Any] = []
 
     while True:
         try:
@@ -146,32 +132,14 @@ def chat_command(workspace_ref: str, session_id: str | None) -> None:
 
         if not user_text:
             continue
-
         if user_text.lower() in {"exit", "quit"}:
             click.echo("Exiting chat.")
             break
 
-        store.append(
-            session_id,
-            "user",
-            user_text,
-            meta={"source": "cli-chat"},
-        )
+        store.append(session_id, "user", user_text, meta={"source": "cli-chat"})
+        click.echo("  (thinking…)")
 
-        reply = _run_agent(
-            user_text=user_text,
-            context=context,
-            workspace=workspace,
-            session_id=session_id,
-        )
+        reply = await _run_agent(user_text, message_history)
 
-        store.append(
-            session_id,
-            "assistant",
-            reply,
-            meta={"source": "cli-chat"},
-        )
-
-        click.echo("")
-        click.echo(reply)
-        click.echo("")
+        store.append(session_id, "assistant", reply, meta={"source": "cli-chat"})
+        click.echo(f"\n{reply}\n")

--- a/src/miminions/memory/distiller.py
+++ b/src/miminions/memory/distiller.py
@@ -1,0 +1,22 @@
+"""Memory distiller stub — placeholder until the long-term-memory branch is merged."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def llm_filter(transcript: str = "", **_kwargs: Any) -> dict[str, Any]:
+    """Stub context injected into the agent as its base identity prompt.
+
+    Returns a minimal dict that seeds the agent's personality.
+    Replace this with a real LLM extraction call when the memory PR lands.
+    """
+    return {
+        "history_summary": (
+            "You are MiMinions, an agentic AI assistant. "
+            "Help the user with their workspace tasks. "
+            "Use your available tools when relevant."
+        ),
+        "workspace_facts": [],
+        "global_insights": [],
+    }


### PR DESCRIPTION
This pull request introduces a new async chat CLI that connects to a live OpenRouter LLM via `pydantic_ai`, replacing the previous placeholder agent logic. It also adds the OpenAI Python package as a dependency and provides a stub for the memory distiller to seed the agent's base prompt. The most important changes are grouped below.

**LLM Integration and Model Selection:**

* The agent now defaults to using an OpenRouter-backed `OpenAIModel` (via `OpenAIProvider`) if no model is provided, using the `OPENROUTER_API_KEY` from the environment. This replaces the previous `TestModel` placeholder and ensures that the CLI is powered by a real LLM out of the box.
* Added `openai>=1.0.0` to the `pyproject.toml` dependencies to support the LLM integration.

**Async Chat CLI Implementation:**

* Rewrote `src/miminions/interface/cli/chat.py` to provide an async chat loop that interacts with the LLM agent, maintains message history, and registers tools (e.g., `list_registered_tools`) for the agent to use. The CLI now displays the model name and provides improved error handling. [[1]](diffhunk://#diff-91012955bbdfe3b4727e8b7b7f41d6cacf63e2abf1fa50e2ae40a6368f613a77R1-R98) [[2]](diffhunk://#diff-91012955bbdfe3b4727e8b7b7f41d6cacf63e2abf1fa50e2ae40a6368f613a77L121-R125) [[3]](diffhunk://#diff-91012955bbdfe3b4727e8b7b7f41d6cacf63e2abf1fa50e2ae40a6368f613a77L149-R145)

**Memory Distiller Stub:**

* Added `src/miminions/memory/distiller.py` with a stub `llm_filter()` function that returns a minimal identity prompt for the agent. This will later be replaced with a real LLM-based memory extractor.

These changes collectively enable a functional, LLM-powered interactive CLI experience, preparing the codebase for future enhancements like persistent long-term memory.