### PR TITLE
Cli mvp

### DIFF
--- a/chat_test.py
+++ b/chat_test.py
@@ -1,0 +1,44 @@
+"""Quick interactive chat test — run directly with: python chat_test.py"""
+
+import asyncio
+import os
+import sys
+
+sys.path.insert(0, "src")
+
+# Load .env
+with open(".env") as f:
+    for line in f:
+        line = line.strip()
+        if line and "=" in line:
+            k, v = line.split("=", 1)
+            os.environ[k] = v.strip('"')
+
+from miminions.agent import create_minion
+from miminions.memory.distiller import llm_filter
+
+
+async def chat():
+    minion = create_minion(
+        name="MiMinions",
+        description=llm_filter()["history_summary"],
+    )
+    history = []
+    print("MiMinions ready. Type 'exit' to quit.\n")
+
+    while True:
+        try:
+            msg = input("> ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print("\nBye.")
+            break
+
+        if not msg or msg.lower() == "exit":
+            break
+
+        reply = await minion.run(msg, message_history=history)
+        history = minion._last_messages
+        print(f"\n{reply}\n")
+
+
+asyncio.run(chat())

--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -70,11 +70,17 @@ class RegisteredTool:
 
 class Minion:
     """
-    Minion agent implementation.
-    
-    Uses pydantic_ai infrastructure for LLM-ready tool management.
-    Currently operates in direct execution mode (no LLM) but structured
-    for easy LLM integration by replacing TestModel with a real model.
+    Minion — an LLM-powered agent built on top of pydantic_ai.
+
+    Minion owns the full agent lifecycle: model config, tool registry, and the
+    async reasoning loop.  Callers interact only with Minion — the underlying
+    pydantic_ai Agent is a private implementation detail.
+
+    Typical usage::
+
+        minion = create_minion(name="MyAgent", description="...")
+        minion.register_tool("do_thing", "Does a thing", do_thing)
+        reply = await minion.run("Please do the thing")
     """
 
     def __init__(

--- a/src/miminions/cli/chat.py
+++ b/src/miminions/cli/chat.py
@@ -11,49 +11,8 @@ import click
 from miminions.agent import create_minion
 from miminions.memory import MemoryDistiller
 from miminions.session.store import JsonlSessionStore
-from miminions.core.workspace import WorkspaceManager
+from miminions.core.workspace import WorkspaceManager, ensure_workspace
 from miminions.cli.auth import get_config_dir
-
-
-# ---------------------------------------------------------------------------
-# Workspace resolution
-# ---------------------------------------------------------------------------
-
-
-def _resolve_workspace(manager: Any, workspace_ref: str) -> tuple[Any, Path]:
-    """Resolve a workspace by id or name, validate its root_path, and return (workspace, root)."""
-    workspaces = manager.load_workspaces()
-
-    workspace = None
-    if workspaces:
-        if workspace_ref in workspaces:
-            workspace = workspaces[workspace_ref]
-        else:
-            for workspace_id, ws in workspaces.items():
-                if str(workspace_id) == workspace_ref:
-                    workspace = ws
-                    break
-                if getattr(ws, "id", None) is not None and str(ws.id) == workspace_ref:
-                    workspace = ws
-                    break
-                if getattr(ws, "name", None) is not None and str(ws.name) == workspace_ref:
-                    workspace = ws
-                    break
-
-    if workspace is None:
-        raise click.ClickException(f"Workspace not found: {workspace_ref}")
-
-    root_path = getattr(workspace, "root_path", None)
-    if not root_path:
-        raise click.ClickException(
-            "This workspace has no root_path yet. Run workspace init-files first."
-        )
-
-    root = Path(root_path)
-    if not root.exists():
-        raise click.ClickException(f"Workspace root_path does not exist: {root}")
-
-    return workspace, root
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +99,10 @@ async def _chat_loop(workspace_ref: str, session_id: str | None) -> None:
     6. On exit, run session distillation in the finally block.
     """
     manager = WorkspaceManager(get_config_dir())
-    workspace, root = _resolve_workspace(manager, workspace_ref)
+    try:
+        workspace, root = ensure_workspace(manager, workspace_ref)
+    except (ValueError, FileNotFoundError) as exc:
+        raise click.ClickException(str(exc)) from exc
 
     store = JsonlSessionStore(root)
 

--- a/src/miminions/cli/main.py
+++ b/src/miminions/cli/main.py
@@ -12,6 +12,7 @@ from .knowledge import knowledge_cli
 from .workspace import workspace_cli
 from .execution import execution_cli
 from .chat import chat_cli
+from .prompt import prompt_cli
 
 
 @click.group()
@@ -30,6 +31,7 @@ cli.add_command(knowledge_cli, name="knowledge")
 cli.add_command(workspace_cli, name="workspace")
 cli.add_command(execution_cli, name="execution")
 cli.add_command(chat_cli, name="chat")
+cli.add_command(prompt_cli, name="prompt")
 
 def main():
     """Entry point for the CLI."""

--- a/src/miminions/cli/prompt.py
+++ b/src/miminions/cli/prompt.py
@@ -1,0 +1,107 @@
+"""One-shot prompt CLI for the MiMinions runtime."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import click
+
+from miminions.agent import create_minion
+from miminions.agent.context_builder import ContextBuilder
+from miminions.core.workspace import Workspace, WorkspaceManager
+from miminions.interface.cli.auth import get_config_dir
+from miminions.session.store import JsonlSessionStore
+from miminions.workspace_fs import init_workspace
+
+
+@click.group()
+def prompt_cli() -> None:
+    """Prompt commands."""
+    pass
+
+
+@prompt_cli.command("ask")
+@click.option("--workspace", "workspace_ref", default="default", show_default=True, help="Workspace id or name.")
+@click.option("--session", "session_id", default=None, help="Optional existing session id.")
+@click.argument("prompt_parts", nargs=-1, required=True)
+def ask_prompt(workspace_ref: str, session_id: str | None, prompt_parts: tuple[str, ...]) -> None:
+    """Send a single prompt to the Minion runtime."""
+    user_prompt = " ".join(prompt_parts).strip()
+    if not user_prompt:
+        raise click.ClickException("Prompt cannot be empty.")
+
+    asyncio.run(_ask_prompt(workspace_ref, session_id, user_prompt))
+
+
+def _resolve_workspace(workspaces: dict[str, Workspace], workspace_ref: str) -> Workspace | None:
+    """Resolve a workspace by exact id, id prefix, or exact name."""
+    if workspace_ref in workspaces:
+        return workspaces[workspace_ref]
+
+    for workspace_id, workspace in workspaces.items():
+        if workspace_id.startswith(workspace_ref):
+            return workspace
+        if str(getattr(workspace, "id", "")) == workspace_ref:
+            return workspace
+        if str(getattr(workspace, "name", "")) == workspace_ref:
+            return workspace
+
+    return None
+
+
+def _default_root_path(workspace_id: str) -> Path:
+    """Return the default on-disk root for a workspace."""
+    return (Path("~/.miminions/workspaces").expanduser() / f"ws_{workspace_id}").resolve()
+
+
+def _ensure_workspace(manager: WorkspaceManager, workspace_ref: str) -> tuple[Workspace, Path]:
+    """Resolve or create a workspace and ensure its file layout exists."""
+    workspaces = manager.load_workspaces()
+    workspace = _resolve_workspace(workspaces, workspace_ref)
+
+    if workspace is None:
+        workspace = manager.create_workspace(workspace_ref)
+        workspaces[workspace.id] = workspace
+
+    root_path = getattr(workspace, "root_path", None)
+    if root_path:
+        root = Path(root_path).expanduser().resolve()
+    else:
+        root = _default_root_path(workspace.id)
+        workspace.root_path = str(root)
+
+    init_workspace(root)
+    manager.save_workspaces(workspaces)
+    return workspace, root
+
+
+async def _ask_prompt(workspace_ref: str, session_id: str | None, user_prompt: str) -> None:
+    """Run the one-shot prompt flow and print the assistant response."""
+    manager = WorkspaceManager(get_config_dir())
+    workspace, root = _ensure_workspace(manager, workspace_ref)
+
+    store = JsonlSessionStore(root)
+    if not session_id:
+        session_id = store.create_session_id()
+
+    meta: dict[str, Any] = {
+        "source": "cli-prompt",
+        "workspace_id": workspace.id,
+    }
+
+    store.append(session_id, "user", user_prompt, meta=meta)
+
+    context = ContextBuilder().build(workspace, root)
+    minion = create_minion(name="MiMinions", description=context)
+
+    try:
+        reply = await minion.run(user_prompt)
+    except Exception as exc:
+        error_text = f"[error] {type(exc).__name__}: {exc}"
+        store.append(session_id, "assistant", error_text, meta={**meta, "error": True})
+        raise click.ClickException(error_text) from exc
+
+    store.append(session_id, "assistant", reply, meta=meta)
+    click.echo(reply)

--- a/src/miminions/cli/prompt.py
+++ b/src/miminions/cli/prompt.py
@@ -3,17 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from pathlib import Path
 from typing import Any
 
 import click
 
 from miminions.agent import create_minion
-from miminions.agent.context_builder import ContextBuilder
-from miminions.core.workspace import Workspace, WorkspaceManager
-from miminions.interface.cli.auth import get_config_dir
+from miminions.context import ContextBuilder
+from miminions.core.workspace import WorkspaceManager, ensure_workspace
+from miminions.cli.auth import get_config_dir
 from miminions.session.store import JsonlSessionStore
-from miminions.workspace_fs import init_workspace
 
 
 @click.group()
@@ -35,52 +33,10 @@ def ask_prompt(workspace_ref: str, session_id: str | None, prompt_parts: tuple[s
     asyncio.run(_ask_prompt(workspace_ref, session_id, user_prompt))
 
 
-def _resolve_workspace(workspaces: dict[str, Workspace], workspace_ref: str) -> Workspace | None:
-    """Resolve a workspace by exact id, id prefix, or exact name."""
-    if workspace_ref in workspaces:
-        return workspaces[workspace_ref]
-
-    for workspace_id, workspace in workspaces.items():
-        if workspace_id.startswith(workspace_ref):
-            return workspace
-        if str(getattr(workspace, "id", "")) == workspace_ref:
-            return workspace
-        if str(getattr(workspace, "name", "")) == workspace_ref:
-            return workspace
-
-    return None
-
-
-def _default_root_path(workspace_id: str) -> Path:
-    """Return the default on-disk root for a workspace."""
-    return (Path("~/.miminions/workspaces").expanduser() / f"ws_{workspace_id}").resolve()
-
-
-def _ensure_workspace(manager: WorkspaceManager, workspace_ref: str) -> tuple[Workspace, Path]:
-    """Resolve or create a workspace and ensure its file layout exists."""
-    workspaces = manager.load_workspaces()
-    workspace = _resolve_workspace(workspaces, workspace_ref)
-
-    if workspace is None:
-        workspace = manager.create_workspace(workspace_ref)
-        workspaces[workspace.id] = workspace
-
-    root_path = getattr(workspace, "root_path", None)
-    if root_path:
-        root = Path(root_path).expanduser().resolve()
-    else:
-        root = _default_root_path(workspace.id)
-        workspace.root_path = str(root)
-
-    init_workspace(root)
-    manager.save_workspaces(workspaces)
-    return workspace, root
-
-
 async def _ask_prompt(workspace_ref: str, session_id: str | None, user_prompt: str) -> None:
     """Run the one-shot prompt flow and print the assistant response."""
     manager = WorkspaceManager(get_config_dir())
-    workspace, root = _ensure_workspace(manager, workspace_ref)
+    workspace, root = ensure_workspace(manager, workspace_ref, create_missing=True, init_files=True)
 
     store = JsonlSessionStore(root)
     if not session_id:

--- a/src/miminions/context/context_builder.py
+++ b/src/miminions/context/context_builder.py
@@ -7,8 +7,15 @@ from pathlib import Path
 from typing import Any
 
 from miminions.memory.md_store import read_memory
-from miminions.memory.sqlite import SQLiteMemory, get_global_memory_db_path
 from miminions.workspace_fs.reader import list_skills, read_prompt_files
+
+
+def get_global_memory_db_path(create_dir: bool = True) -> str:
+    """Return canonical path for cross-workspace global memory DB."""
+    path = Path.home() / ".miminions" / "global_memory.db"
+    if create_dir:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 def _safe_get(obj: Any, name: str, default: Any = None) -> Any:
@@ -134,6 +141,8 @@ def _fetch_global_insights(top_k: int = 5, db_path: str | None = None) -> list[s
     """Return top-k plain-text global insights from SQLite, or [] on any failure."""
     path = db_path or get_global_memory_db_path(create_dir=False)
     try:
+        from miminions.memory.sqlite import SQLiteMemory
+
         mem = SQLiteMemory(db_path=path)
         try:
             rows = mem.date_time_search(top_k=top_k)

--- a/src/miminions/core/workspace.py
+++ b/src/miminions/core/workspace.py
@@ -8,9 +8,12 @@ and structured logic based on internal state.
 import json
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, List, Optional, Any, Union
 from dataclasses import dataclass, asdict, field
 from enum import Enum
+
+DEFAULT_WORKSPACES_ROOT = Path("~/.miminions/workspaces").expanduser()
 
 
 class NodeType(Enum):
@@ -435,3 +438,62 @@ class WorkspaceManager:
         }
         
         return workspace
+
+
+def resolve_workspace(workspaces: Dict[str, Workspace], workspace_ref: str) -> Workspace | None:
+    """Resolve a workspace by exact id, id prefix, or exact name."""
+    if workspace_ref in workspaces:
+        return workspaces[workspace_ref]
+
+    for workspace_id, workspace in workspaces.items():
+        if str(workspace_id).startswith(workspace_ref):
+            return workspace
+        if str(getattr(workspace, "id", "")) == workspace_ref:
+            return workspace
+        if str(getattr(workspace, "name", "")) == workspace_ref:
+            return workspace
+
+    return None
+
+
+def default_workspace_root(workspace_id: str) -> Path:
+    """Return the default on-disk root for a workspace."""
+    return (DEFAULT_WORKSPACES_ROOT / f"ws_{workspace_id}").resolve()
+
+
+def ensure_workspace(
+    manager: WorkspaceManager,
+    workspace_ref: str,
+    *,
+    create_missing: bool = False,
+    init_files: bool = False,
+) -> tuple[Workspace, Path]:
+    """Resolve or create a workspace and return it with its root path."""
+    workspaces = manager.load_workspaces()
+    workspace = resolve_workspace(workspaces, workspace_ref)
+
+    if workspace is None:
+        if not create_missing:
+            raise ValueError(f"Workspace not found: {workspace_ref}")
+
+        workspace = manager.create_workspace(workspace_ref)
+        workspaces[workspace.id] = workspace
+
+    root_path = getattr(workspace, "root_path", None)
+    if root_path:
+        root = Path(root_path).expanduser().resolve()
+    elif init_files:
+        root = default_workspace_root(workspace.id)
+        workspace.root_path = str(root)
+    else:
+        raise ValueError("This workspace has no root_path yet. Run workspace init-files first.")
+
+    if init_files:
+        from miminions.workspace_fs import init_workspace
+
+        init_workspace(root)
+        manager.save_workspaces(workspaces)
+    elif not root.exists():
+        raise FileNotFoundError(f"Workspace root_path does not exist: {root}")
+
+    return workspace, root

--- a/src/miminions/memory/distiller.py
+++ b/src/miminions/memory/distiller.py
@@ -10,7 +10,14 @@ from typing import Any, Callable
 from miminions.session.store import JsonlSessionStore
 
 from .md_store import append_history, upsert_memory_section
-from .sqlite import SQLiteMemory, get_global_memory_db_path
+
+
+def get_global_memory_db_path(create_dir: bool = True) -> str:
+    """Return canonical path for cross-workspace global memory DB."""
+    path = Path.home() / ".miminions" / "global_memory.db"
+    if create_dir:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    return str(path)
 
 
 @dataclass
@@ -157,6 +164,8 @@ class MemoryDistiller:
 
         if global_insights:
             try:
+                from .sqlite import SQLiteMemory
+
                 sqlite_memory = SQLiteMemory(db_path=self.global_db_path)
                 try:
                     for insight_text in global_insights:

--- a/tests/integration/test_prompt.py
+++ b/tests/integration/test_prompt.py
@@ -1,0 +1,171 @@
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from miminions.core.workspace import Workspace, WorkspaceManager
+from miminions.interface.cli.main import cli
+from miminions.workspace_fs.bootstrap import init_workspace
+
+
+class FakeMinion:
+    def __init__(self, reply: str = "assistant reply", error: Exception | None = None):
+        self.reply = reply
+        self.error = error
+        self.prompts = []
+
+    async def run(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if self.error:
+            raise self.error
+        return self.reply
+
+
+def _patch_prompt_runtime(monkeypatch, tmp_path: Path, fake_minion: FakeMinion | None = None) -> FakeMinion:
+    fake = fake_minion or FakeMinion()
+
+    monkeypatch.setattr(
+        "miminions.interface.cli.prompt.get_config_dir",
+        lambda: tmp_path / "config",
+    )
+    monkeypatch.setattr(
+        "miminions.interface.cli.prompt._default_root_path",
+        lambda workspace_id: tmp_path / "workspaces" / f"ws_{workspace_id}",
+    )
+    monkeypatch.setattr(
+        "miminions.interface.cli.prompt.create_minion",
+        lambda name, description: fake,
+    )
+
+    return fake
+
+
+def _read_workspace_data(config_dir: Path) -> dict:
+    return json.loads((config_dir / "workspaces.json").read_text(encoding="utf-8"))
+
+
+def _session_records(root: Path, session_id: str | None = None) -> list[dict]:
+    if session_id:
+        session_file = root / "sessions" / f"{session_id}.jsonl"
+    else:
+        session_files = list((root / "sessions").glob("*.jsonl"))
+        assert len(session_files) == 1, f"Expected one session file, found {len(session_files)}"
+        session_file = session_files[0]
+
+    return [
+        json.loads(line)
+        for line in session_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+
+
+def test_prompt_ask_creates_default_workspace_files_logs_and_prints(tmp_path, monkeypatch):
+    fake = _patch_prompt_runtime(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        ["prompt", "ask", "book a chinese food restaurant at 6 pm today"],
+    )
+
+    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}: {result.output}"
+    assert result.output == "assistant reply\n", f"Expected assistant-only output, got: {result.output}"
+    assert fake.prompts == ["book a chinese food restaurant at 6 pm today"]
+
+    config_dir = tmp_path / "config"
+    workspace_data = _read_workspace_data(config_dir)
+    assert len(workspace_data) == 1, f"Expected one workspace, got: {workspace_data}"
+
+    workspace_id, workspace = next(iter(workspace_data.items()))
+    assert workspace["name"] == "default"
+
+    root = tmp_path / "workspaces" / f"ws_{workspace_id}"
+    assert workspace["root_path"] == str(root)
+    assert (root / "prompt" / "AGENTS.md").exists()
+    assert (root / "memory" / "MEMORY.md").exists()
+    assert (root / "skills" / "core" / "SKILL.md").exists()
+
+    records = _session_records(root)
+    assert [record["role"] for record in records] == ["user", "assistant"]
+    assert records[0]["content"] == "book a chinese food restaurant at 6 pm today"
+    assert records[1]["content"] == "assistant reply"
+    assert records[0]["meta"]["source"] == "cli-prompt"
+    assert records[0]["meta"]["workspace_id"] == workspace_id
+
+
+def test_prompt_ask_initializes_existing_workspace_without_root_path(tmp_path, monkeypatch):
+    _patch_prompt_runtime(monkeypatch, tmp_path)
+
+    config_dir = tmp_path / "config"
+    manager = WorkspaceManager(config_dir)
+    workspace = Workspace(name="existing")
+    manager.save_workspaces({workspace.id: workspace})
+
+    result = CliRunner().invoke(cli, ["prompt", "ask", "--workspace", "existing", "hello"])
+
+    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}: {result.output}"
+
+    workspace_data = _read_workspace_data(config_dir)
+    saved_workspace = workspace_data[workspace.id]
+    root = tmp_path / "workspaces" / f"ws_{workspace.id}"
+    assert saved_workspace["root_path"] == str(root)
+    assert (root / "prompt" / "AGENTS.md").exists()
+    assert (root / "sessions").exists()
+
+
+def test_prompt_ask_reuses_existing_initialized_workspace_root(tmp_path, monkeypatch):
+    _patch_prompt_runtime(monkeypatch, tmp_path)
+
+    config_dir = tmp_path / "config"
+    root = tmp_path / "custom-root"
+    init_workspace(root)
+
+    manager = WorkspaceManager(config_dir)
+    workspace = Workspace(name="ready")
+    workspace.root_path = str(root)
+    manager.save_workspaces({workspace.id: workspace})
+
+    result = CliRunner().invoke(cli, ["prompt", "ask", "--workspace", workspace.id[:8], "hello"])
+
+    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}: {result.output}"
+
+    workspace_data = _read_workspace_data(config_dir)
+    assert workspace_data[workspace.id]["root_path"] == str(root)
+    records = _session_records(root)
+    assert records[0]["content"] == "hello"
+
+
+def test_prompt_ask_writes_to_requested_session(tmp_path, monkeypatch):
+    _patch_prompt_runtime(monkeypatch, tmp_path)
+
+    result = CliRunner().invoke(
+        cli,
+        ["prompt", "ask", "--session", "known-session", "hello", "there"],
+    )
+
+    assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}: {result.output}"
+
+    workspace_data = _read_workspace_data(tmp_path / "config")
+    workspace_id = next(iter(workspace_data))
+    root = tmp_path / "workspaces" / f"ws_{workspace_id}"
+    records = _session_records(root, "known-session")
+
+    assert [record["session_id"] for record in records] == ["known-session", "known-session"]
+    assert records[0]["content"] == "hello there"
+
+
+def test_prompt_ask_logs_runtime_error_and_exits_nonzero(tmp_path, monkeypatch):
+    _patch_prompt_runtime(monkeypatch, tmp_path, FakeMinion(error=RuntimeError("runtime failed")))
+
+    result = CliRunner().invoke(cli, ["prompt", "ask", "hello"])
+
+    assert result.exit_code != 0, "Expected a non-zero exit code for runtime failure"
+    assert "RuntimeError: runtime failed" in result.output
+
+    workspace_data = _read_workspace_data(tmp_path / "config")
+    workspace_id = next(iter(workspace_data))
+    root = tmp_path / "workspaces" / f"ws_{workspace_id}"
+    records = _session_records(root)
+
+    assert [record["role"] for record in records] == ["user", "assistant"]
+    assert records[1]["content"] == "[error] RuntimeError: runtime failed"
+    assert records[1]["meta"]["error"] is True

--- a/tests/integration/test_prompt.py
+++ b/tests/integration/test_prompt.py
@@ -1,39 +1,29 @@
 import json
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 from click.testing import CliRunner
 
 from miminions.core.workspace import Workspace, WorkspaceManager
-from miminions.interface.cli.main import cli
+from miminions.cli.main import cli
 from miminions.workspace_fs.bootstrap import init_workspace
 
 
-class FakeMinion:
-    def __init__(self, reply: str = "assistant reply", error: Exception | None = None):
-        self.reply = reply
-        self.error = error
-        self.prompts = []
-
-    async def run(self, prompt: str) -> str:
-        self.prompts.append(prompt)
-        if self.error:
-            raise self.error
-        return self.reply
-
-
-def _patch_prompt_runtime(monkeypatch, tmp_path: Path, fake_minion: FakeMinion | None = None) -> FakeMinion:
-    fake = fake_minion or FakeMinion()
+def _patch_prompt_runtime(monkeypatch, tmp_path: Path, fake_minion: MagicMock | None = None) -> MagicMock:
+    fake = fake_minion or MagicMock()
+    if not hasattr(fake, "run") or not isinstance(fake.run, AsyncMock):
+        fake.run = AsyncMock(return_value="assistant reply")
 
     monkeypatch.setattr(
-        "miminions.interface.cli.prompt.get_config_dir",
+        "miminions.cli.prompt.get_config_dir",
         lambda: tmp_path / "config",
     )
     monkeypatch.setattr(
-        "miminions.interface.cli.prompt._default_root_path",
-        lambda workspace_id: tmp_path / "workspaces" / f"ws_{workspace_id}",
+        "miminions.core.workspace.DEFAULT_WORKSPACES_ROOT",
+        tmp_path / "workspaces",
     )
     monkeypatch.setattr(
-        "miminions.interface.cli.prompt.create_minion",
+        "miminions.cli.prompt.create_minion",
         lambda name, description: fake,
     )
 
@@ -69,7 +59,7 @@ def test_prompt_ask_creates_default_workspace_files_logs_and_prints(tmp_path, mo
 
     assert result.exit_code == 0, f"Expected exit code 0, got {result.exit_code}: {result.output}"
     assert result.output == "assistant reply\n", f"Expected assistant-only output, got: {result.output}"
-    assert fake.prompts == ["book a chinese food restaurant at 6 pm today"]
+    fake.run.assert_awaited_once_with("book a chinese food restaurant at 6 pm today")
 
     config_dir = tmp_path / "config"
     workspace_data = _read_workspace_data(config_dir)
@@ -154,11 +144,13 @@ def test_prompt_ask_writes_to_requested_session(tmp_path, monkeypatch):
 
 
 def test_prompt_ask_logs_runtime_error_and_exits_nonzero(tmp_path, monkeypatch):
-    _patch_prompt_runtime(monkeypatch, tmp_path, FakeMinion(error=RuntimeError("runtime failed")))
+    fake = MagicMock()
+    fake.run = AsyncMock(side_effect=RuntimeError("runtime failed"))
+    _patch_prompt_runtime(monkeypatch, tmp_path, fake)
 
     result = CliRunner().invoke(cli, ["prompt", "ask", "hello"])
 
-    assert result.exit_code != 0, "Expected a non-zero exit code for runtime failure"
+    assert result.exit_code != 0, f"Expected non-zero exit code for runtime failure, got {result.exit_code}"
     assert "RuntimeError: runtime failed" in result.output
 
     workspace_data = _read_workspace_data(tmp_path / "config")


### PR DESCRIPTION
## Description

This PR adds the MVP one-shot prompt flow for the MiMinions CLI. Users can now run a prompt directly from the command line using `miminions prompt ask "..."`.

## PR Information

| Field | Value |
|-------|-------|
| **Type** | New feature |
| **Priority** | High |
| **Breaking Change** | No |
| **Tests Added** | Yes |
| **Documentation Updated** | No |

## Changes Made

- Added a new `prompt` CLI command group and registered it with the main CLI
- Added `miminions prompt ask` with support for quoted prompts, multi-token prompts, optional workspace selection, and optional session reuse
- Connected the one-shot prompt flow to `ContextBuilder` so the runtime uses workspace context
- Connected workspace initialization so the required workspace folders and files are created before context loading
- Added JSONL session tracing for user prompts, assistant responses, and runtime errors
- Added tests

## Testing

Unit tests in test_prompt.py