### PR TITLE
refactor(cli): consolidate require_auth into core auth module

### DIFF
--- a/src/miminions/interface/cli/agent.py
+++ b/src/miminions/interface/cli/agent.py
@@ -6,7 +6,8 @@ import click
 import json
 import re
 from datetime import datetime, timezone
-from .auth import get_config_dir, is_authenticated, is_public_access_enabled
+from .auth import get_config_dir
+from miminions.core.auth import require_auth
 from miminions.agent import create_minion
 
 
@@ -112,35 +113,6 @@ def _execute_prompt_with_tool_fallback(runtime_agent, prompt):
     return output
 
 
-# TODO: require_auth disabled until auth is fully implemented
-# and the public-access path is clear to users.
-# def require_auth():
-#     """Decorator to require authentication or allow public access."""
-#     def decorator(f):
-#         def wrapper(*args, **kwargs):
-#             if not is_authenticated():
-#                 if is_public_access_enabled():
-#                     # Show warning but allow access
-#                     click.echo("⚠️  Running in public access mode. Sign in for full functionality.", err=True)
-#                 else:
-#                     # Require authentication
-#                     click.echo("Please sign in first using 'miminions auth signin'", err=True)
-#                     return
-#             return f(*args, **kwargs)
-#         return wrapper
-#     return decorator
-def require_auth():
-    """Temporary no-op decorator while auth is being stabilized."""
-    # NOTE(auth-tests): When restoring real auth enforcement here,
-    # re-enable the commented assertions in:
-    # - tests/cli/test_agent.py::TestAgentCLI.test_list_agents_not_authenticated
-    # - tests/cli/test_agent.py::TestAgentCLI.test_add_agent_not_authenticated
-    # E2E updates are intentionally handled in a separate stream.
-    def decorator(f):
-        return f
-    return decorator
-
-
 @click.group()
 def agent_cli():
     """Agent management commands."""
@@ -148,7 +120,7 @@ def agent_cli():
 
 
 @agent_cli.command("list")
-@require_auth()
+@require_auth
 def list_agents():
     """List all agents."""
     agents = load_agents()
@@ -169,12 +141,11 @@ def list_agents():
 @click.option("--name", prompt="Agent name", help="Name of the agent")
 @click.option("--description", prompt="Description", help="Description of the agent")
 @click.option("--type", prompt="Agent type", help="Type of agent")
-@require_auth()
+@require_auth
 def add_agent(name, description, type):
     """Add a new agent."""
     agents = load_agents()
     
-    # Generate a simple ID based on name
     agent_id = name.lower().replace(" ", "_")
     
     if agent_id in agents:
@@ -201,7 +172,7 @@ def add_agent(name, description, type):
 @click.option("--name", help="New name for the agent")
 @click.option("--description", help="New description for the agent")
 @click.option("--type", help="New type for the agent")
-@require_auth()
+@require_auth
 def update_agent(agent_id, name, description, type):
     """Update an existing agent."""
     agents = load_agents()
@@ -226,7 +197,7 @@ def update_agent(agent_id, name, description, type):
 @agent_cli.command("remove")
 @click.argument("agent_id")
 @click.confirmation_option(prompt="Are you sure you want to remove this agent?")
-@require_auth()
+@require_auth
 def remove_agent(agent_id):
     """Remove an agent."""
     agents = load_agents()
@@ -243,7 +214,7 @@ def remove_agent(agent_id):
 @agent_cli.command("set-goal")
 @click.argument("agent_id")
 @click.option("--goal", prompt="Goal", help="Goal for the agent")
-@require_auth()
+@require_auth
 def set_goal(agent_id, goal):
     """Set a goal for an agent."""
     agents = load_agents()
@@ -260,7 +231,7 @@ def set_goal(agent_id, goal):
 @agent_cli.command("run")
 @click.argument("agent_id")
 @click.option("--async", "async_run", is_flag=True, help="Run agent asynchronously")
-@require_auth()
+@require_auth
 def run_agent(agent_id, async_run):
     """Run an agent."""
     agents = load_agents()
@@ -277,7 +248,6 @@ def run_agent(agent_id, async_run):
 
     runtime_agent = _build_cli_extension_agent(agent)
     
-    # Update status
     agents[agent_id]["status"] = "running"
     save_agents(agents)
     
@@ -300,7 +270,7 @@ def run_agent(agent_id, async_run):
 @agent_cli.command("ask")
 @click.argument("agent_id")
 @click.option("--prompt", required=True, help="Prompt to send to the agent.")
-@require_auth()
+@require_auth
 def ask_agent(agent_id, prompt):
     """Ask an agent for a one-off response without mutating its stored goal."""
     agent_data = _get_agent_record_or_error(agent_id)
@@ -315,7 +285,7 @@ def ask_agent(agent_id, prompt):
 
 @agent_cli.command("tool-list")
 @click.argument("agent_id")
-@require_auth()
+@require_auth
 def list_agent_tools(agent_id):
     """List available tools for an agent runtime."""
     agent_data = _get_agent_record_or_error(agent_id)
@@ -338,7 +308,7 @@ def list_agent_tools(agent_id):
 @agent_cli.command("tool-info")
 @click.argument("agent_id")
 @click.argument("tool_name")
-@require_auth()
+@require_auth
 def show_agent_tool_info(agent_id, tool_name):
     """Show detailed tool information for one tool."""
     agent_data = _get_agent_record_or_error(agent_id)
@@ -360,7 +330,7 @@ def show_agent_tool_info(agent_id, tool_name):
 @agent_cli.command("tool-search")
 @click.argument("agent_id")
 @click.argument("query")
-@require_auth()
+@require_auth
 def search_agent_tools(agent_id, query):
     """Search tools by name or description."""
     agent_data = _get_agent_record_or_error(agent_id)
@@ -386,7 +356,7 @@ def search_agent_tools(agent_id, query):
     default="{}",
     help="JSON object with tool arguments, e.g. '{\"a\":2,\"b\":3}'.",
 )
-@require_auth()
+@require_auth
 def run_agent_tool(agent_id, tool_name, arguments):
     """Run one tool and print structured execution output."""
     agent_data = _get_agent_record_or_error(agent_id)

--- a/src/miminions/interface/cli/knowledge.py
+++ b/src/miminions/interface/cli/knowledge.py
@@ -6,7 +6,8 @@ import click
 import json
 import uuid
 from pathlib import Path
-from .auth import get_config_dir, is_authenticated, is_public_access_enabled
+from .auth import get_config_dir
+from miminions.core.auth import require_auth
 
 
 def get_knowledge_file():
@@ -31,30 +32,6 @@ def save_knowledge(knowledge):
         json.dump(knowledge, f, indent=2)
 
 
-# TODO: require_auth disabled until auth is fully implemented
-# and the public-access path is clear to users.
-# def require_auth():
-#     """Decorator to require authentication or allow public access."""
-#     def decorator(f):
-#         def wrapper(*args, **kwargs):
-#             if not is_authenticated():
-#                 if is_public_access_enabled():
-#                     # Show warning but allow access
-#                     click.echo("⚠️  Running in public access mode. Sign in for full functionality.", err=True)
-#                 else:
-#                     # Require authentication
-#                     click.echo("Please sign in first using 'miminions auth signin'", err=True)
-#                     return
-#             return f(*args, **kwargs)
-#         return wrapper
-#     return decorator
-def require_auth():
-    """Temporary no-op decorator while auth is being stabilized."""
-    def decorator(f):
-        return f
-    return decorator
-
-
 @click.group()
 def knowledge_cli():
     """Knowledge management commands."""
@@ -62,7 +39,7 @@ def knowledge_cli():
 
 
 @knowledge_cli.command("list")
-@require_auth()
+@require_auth
 def list_knowledge():
     """List all knowledge entries."""
     knowledge = load_knowledge()
@@ -85,12 +62,11 @@ def list_knowledge():
 @click.option("--content", prompt="Content", help="Content of the knowledge entry")
 @click.option("--category", default="general", help="Category of the knowledge entry")
 @click.option("--tags", help="Comma-separated tags")
-@require_auth()
+@require_auth
 def add_knowledge(title, content, category, tags):
     """Add a new knowledge entry."""
     knowledge = load_knowledge()
     
-    # Generate a unique ID
     entry_id = str(uuid.uuid4())[:8]
     
     tag_list = []
@@ -125,7 +101,7 @@ def add_knowledge(title, content, category, tags):
 @click.option("--content", help="New content for the knowledge entry")
 @click.option("--category", help="New category for the knowledge entry")
 @click.option("--tags", help="Comma-separated tags")
-@require_auth()
+@require_auth
 def update_knowledge(entry_id, title, content, category, tags):
     """Update an existing knowledge entry."""
     knowledge = load_knowledge()
@@ -136,12 +112,10 @@ def update_knowledge(entry_id, title, content, category, tags):
     
     entry = knowledge[entry_id]
     
-    # If content is being updated, create a new version
     if content and content != entry["content"]:
         current_version = float(entry["version"])
         new_version = f"{current_version + 0.1:.1f}"
         
-        # Add new version to history
         entry["versions"].append({
             "version": new_version,
             "content": content,
@@ -167,7 +141,7 @@ def update_knowledge(entry_id, title, content, category, tags):
 @knowledge_cli.command("remove")
 @click.argument("entry_id")
 @click.confirmation_option(prompt="Are you sure you want to remove this knowledge entry?")
-@require_auth()
+@require_auth
 def remove_knowledge(entry_id):
     """Remove a knowledge entry."""
     knowledge = load_knowledge()
@@ -184,7 +158,7 @@ def remove_knowledge(entry_id):
 @knowledge_cli.command("revert")
 @click.argument("entry_id")
 @click.option("--version", prompt="Version to revert to", help="Version to revert to")
-@require_auth()
+@require_auth
 def revert_knowledge(entry_id, version):
     """Revert a knowledge entry to a previous version."""
     knowledge = load_knowledge()
@@ -195,7 +169,6 @@ def revert_knowledge(entry_id, version):
     
     entry = knowledge[entry_id]
     
-    # Find the version to revert to
     target_version = None
     for v in entry["versions"]:
         if v["version"] == version:
@@ -206,7 +179,6 @@ def revert_knowledge(entry_id, version):
         click.echo(f"Version '{version}' not found for entry '{entry_id}'.", err=True)
         return
     
-    # Revert to the target version
     entry["content"] = target_version["content"]
     entry["version"] = target_version["version"]
     entry["updated_at"] = click.get_current_context().meta.get("timestamp", "")
@@ -217,7 +189,7 @@ def revert_knowledge(entry_id, version):
 
 @knowledge_cli.command("version")
 @click.argument("entry_id")
-@require_auth()
+@require_auth
 def show_versions(entry_id):
     """Show version history of a knowledge entry."""
     knowledge = load_knowledge()
@@ -238,7 +210,7 @@ def show_versions(entry_id):
 @click.argument("entry_id")
 @click.option("--template", help="Template to apply")
 @click.option("--format", type=click.Choice(["json", "markdown", "plain"]), default="plain", help="Output format")
-@require_auth()
+@require_auth
 def customize_knowledge(entry_id, template, format):
     """Customize knowledge entry format or template."""
     knowledge = load_knowledge()
@@ -250,13 +222,11 @@ def customize_knowledge(entry_id, template, format):
     entry = knowledge[entry_id]
     
     if template:
-        # Apply template (this is a simplified implementation)
         entry["template"] = template
         entry["updated_at"] = click.get_current_context().meta.get("timestamp", "")
         save_knowledge(knowledge)
         click.echo(f"Template '{template}' applied to knowledge entry '{entry_id}'")
     
-    # Display the entry in the requested format
     if format == "json":
         click.echo(json.dumps(entry, indent=2))
     elif format == "markdown":
@@ -272,7 +242,7 @@ def customize_knowledge(entry_id, template, format):
 
 @knowledge_cli.command("show")
 @click.argument("entry_id")
-@require_auth()
+@require_auth
 def show_knowledge(entry_id):
     """Show detailed information about a knowledge entry."""
     knowledge = load_knowledge()

--- a/src/miminions/interface/cli/task.py
+++ b/src/miminions/interface/cli/task.py
@@ -6,7 +6,8 @@ import click
 import json
 import uuid
 from pathlib import Path
-from .auth import get_config_dir, is_authenticated, is_public_access_enabled
+from .auth import get_config_dir
+from miminions.core.auth import require_auth
 
 
 def get_tasks_file():
@@ -31,30 +32,6 @@ def save_tasks(tasks):
         json.dump(tasks, f, indent=2)
 
 
-# TODO: require_auth disabled until auth is fully implemented
-# and the public-access path is clear to users.
-# def require_auth():
-#     """Decorator to require authentication or allow public access."""
-#     def decorator(f):
-#         def wrapper(*args, **kwargs):
-#             if not is_authenticated():
-#                 if is_public_access_enabled():
-#                     # Show warning but allow access
-#                     click.echo("⚠️  Running in public access mode. Sign in for full functionality.", err=True)
-#                 else:
-#                     # Require authentication
-#                     click.echo("Please sign in first using 'miminions auth signin'", err=True)
-#                     return
-#             return f(*args, **kwargs)
-#         return wrapper
-#     return decorator
-def require_auth():
-    """Temporary no-op decorator while auth is being stabilized."""
-    def decorator(f):
-        return f
-    return decorator
-
-
 @click.group()
 def task_cli():
     """Task management commands."""
@@ -62,7 +39,7 @@ def task_cli():
 
 
 @task_cli.command("list")
-@require_auth()
+@require_auth
 def list_tasks():
     """List all tasks."""
     tasks = load_tasks()
@@ -85,12 +62,11 @@ def list_tasks():
 @click.option("--description", prompt="Description", help="Description of the task")
 @click.option("--priority", type=click.Choice(["low", "medium", "high"]), default="medium", help="Priority level")
 @click.option("--agent", help="Agent ID to assign the task to")
-@require_auth()
+@require_auth
 def add_task(title, description, priority, agent):
     """Add a new task."""
     tasks = load_tasks()
     
-    # Generate a unique ID
     task_id = str(uuid.uuid4())[:8]
     
     tasks[task_id] = {
@@ -114,7 +90,7 @@ def add_task(title, description, priority, agent):
 @click.option("--priority", type=click.Choice(["low", "medium", "high"]), help="New priority level")
 @click.option("--status", type=click.Choice(["pending", "in_progress", "completed", "cancelled"]), help="New status")
 @click.option("--agent", help="Agent ID to assign the task to")
-@require_auth()
+@require_auth
 def update_task(task_id, title, description, priority, status, agent):
     """Update an existing task."""
     tasks = load_tasks()
@@ -145,7 +121,7 @@ def update_task(task_id, title, description, priority, status, agent):
 @task_cli.command("remove")
 @click.argument("task_id")
 @click.confirmation_option(prompt="Are you sure you want to remove this task?")
-@require_auth()
+@require_auth
 def remove_task(task_id):
     """Remove a task."""
     tasks = load_tasks()
@@ -162,7 +138,7 @@ def remove_task(task_id):
 @task_cli.command("duplicate")
 @click.argument("task_id")
 @click.option("--title", help="Title for the duplicated task")
-@require_auth()
+@require_auth
 def duplicate_task(task_id, title):
     """Duplicate an existing task."""
     tasks = load_tasks()
@@ -171,17 +147,14 @@ def duplicate_task(task_id, title):
         click.echo(f"Task '{task_id}' not found.", err=True)
         return
     
-    # Create a copy of the task
     original_task = tasks[task_id].copy()
     new_task_id = str(uuid.uuid4())[:8]
     
-    # Update the title if provided
     if title:
         original_task["title"] = title
     else:
         original_task["title"] = f"{original_task['title']} (copy)"
     
-    # Reset certain fields
     original_task["status"] = "pending"
     original_task["created_at"] = click.get_current_context().meta.get("timestamp", "")
     original_task["updated_at"] = None
@@ -193,7 +166,7 @@ def duplicate_task(task_id, title):
 
 @task_cli.command("show")
 @click.argument("task_id")
-@require_auth()
+@require_auth
 def show_task(task_id):
     """Show detailed information about a task."""
     tasks = load_tasks()

--- a/src/miminions/interface/cli/workflow.py
+++ b/src/miminions/interface/cli/workflow.py
@@ -6,7 +6,8 @@ import click
 import json
 import uuid
 from pathlib import Path
-from .auth import get_config_dir, is_authenticated, is_public_access_enabled
+from .auth import get_config_dir
+from miminions.core.auth import require_auth
 
 
 def get_workflows_file():
@@ -31,30 +32,6 @@ def save_workflows(workflows):
         json.dump(workflows, f, indent=2)
 
 
-# TODO: require_auth disabled until auth is fully implemented
-# and the public-access path is clear to users.
-# def require_auth():
-#     """Decorator to require authentication or allow public access."""
-#     def decorator(f):
-#         def wrapper(*args, **kwargs):
-#             if not is_authenticated():
-#                 if is_public_access_enabled():
-#                     # Show warning but allow access
-#                     click.echo("⚠️  Running in public access mode. Sign in for full functionality.", err=True)
-#                 else:
-#                     # Require authentication
-#                     click.echo("Please sign in first using 'miminions auth signin'", err=True)
-#                     return
-#             return f(*args, **kwargs)
-#         return wrapper
-#     return decorator
-def require_auth():
-    """Temporary no-op decorator while auth is being stabilized."""
-    def decorator(f):
-        return f
-    return decorator
-
-
 @click.group()
 def workflow_cli():
     """Workflow management commands."""
@@ -62,7 +39,7 @@ def workflow_cli():
 
 
 @workflow_cli.command("list")
-@require_auth()
+@require_auth
 def list_workflows():
     """List all workflows."""
     workflows = load_workflows()
@@ -84,12 +61,11 @@ def list_workflows():
 @click.option("--name", prompt="Workflow name", help="Name of the workflow")
 @click.option("--description", prompt="Description", help="Description of the workflow")
 @click.option("--agents", help="Comma-separated list of agent IDs")
-@require_auth()
+@require_auth
 def add_workflow(name, description, agents):
     """Add a new workflow."""
     workflows = load_workflows()
     
-    # Generate a unique ID
     workflow_id = str(uuid.uuid4())[:8]
     
     agent_list = []
@@ -115,7 +91,7 @@ def add_workflow(name, description, agents):
 @click.option("--name", help="New name for the workflow")
 @click.option("--description", help="New description for the workflow")
 @click.option("--agents", help="Comma-separated list of agent IDs")
-@require_auth()
+@require_auth
 def update_workflow(workflow_id, name, description, agents):
     """Update an existing workflow."""
     workflows = load_workflows()
@@ -142,7 +118,7 @@ def update_workflow(workflow_id, name, description, agents):
 @workflow_cli.command("remove")
 @click.argument("workflow_id")
 @click.confirmation_option(prompt="Are you sure you want to remove this workflow?")
-@require_auth()
+@require_auth
 def remove_workflow(workflow_id):
     """Remove a workflow."""
     workflows = load_workflows()
@@ -158,7 +134,7 @@ def remove_workflow(workflow_id):
 
 @workflow_cli.command("start")
 @click.argument("workflow_id")
-@require_auth()
+@require_auth
 def start_workflow(workflow_id):
     """Start a workflow."""
     workflows = load_workflows()
@@ -186,7 +162,7 @@ def start_workflow(workflow_id):
 
 @workflow_cli.command("pause")
 @click.argument("workflow_id")
-@require_auth()
+@require_auth
 def pause_workflow(workflow_id):
     """Pause a running workflow."""
     workflows = load_workflows()
@@ -210,7 +186,7 @@ def pause_workflow(workflow_id):
 
 @workflow_cli.command("stop")
 @click.argument("workflow_id")
-@require_auth()
+@require_auth
 def stop_workflow(workflow_id):
     """Stop a workflow."""
     workflows = load_workflows()
@@ -234,7 +210,7 @@ def stop_workflow(workflow_id):
 
 @workflow_cli.command("show")
 @click.argument("workflow_id")
-@require_auth()
+@require_auth
 def show_workflow(workflow_id):
     """Show detailed information about a workflow."""
     workflows = load_workflows()

--- a/src/miminions/interface/cli/workspace.py
+++ b/src/miminions/interface/cli/workspace.py
@@ -1,42 +1,17 @@
 """
 Workspace management commands for MiMinions CLI.
 """
-
 import click
 import json
 from pathlib import Path
-from .auth import get_config_dir, is_authenticated, is_public_access_enabled
+from .auth import get_config_dir
+from miminions.core.auth import require_auth
 from datetime import datetime, timezone
-
 import sys
 import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 from miminions.core.workspace import WorkspaceManager, Node, Rule, NodeType, RulePriority
 from miminions.workspace_fs import init_workspace
-
-
-# TODO: require_auth disabled until auth is fully implemented
-# and the public-access path is clear to users.
-# def require_auth():
-#     """Decorator to require authentication or allow public access."""
-#     def decorator(f):
-#         def wrapper(*args, **kwargs):
-#             if not is_authenticated():
-#                 if is_public_access_enabled():
-#                     # Show warning but allow access
-#                     click.echo("⚠️  Running in public access mode. Sign in for full functionality.", err=True)
-#                 else:
-#                     # Require authentication
-#                     click.echo("Please sign in first using 'miminions auth signin'", err=True)
-#                     return
-#             return f(*args, **kwargs)
-#         return wrapper
-#     return decorator
-def require_auth():
-    """Temporary no-op decorator while auth is being stabilized."""
-    def decorator(f):
-        return f
-    return decorator
 
 
 def get_workspace_manager():
@@ -49,8 +24,9 @@ def workspace_cli():
     """Workspace management commands."""
     pass
 
+
 @workspace_cli.command("list")
-@require_auth()
+@require_auth
 def list_workspaces():
     """List all workspaces."""
     manager = get_workspace_manager()
@@ -81,13 +57,12 @@ def list_workspaces():
     default=None,
     help="Optional custom root path for this workspace folder. If not set, uses ~/.miminions/workspaces/ws_<id>"
 )
-@require_auth()
+@require_auth
 def add_workspace(name, description, sample, init_files, root_path):
     """Add a new workspace."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Check if workspace name already exists
     for workspace in workspaces.values():
         if workspace.name == name:
             click.echo(f"A workspace named '{name}' already exists.")
@@ -106,10 +81,8 @@ def add_workspace(name, description, sample, init_files, root_path):
             rp = Path(root_path).expanduser().resolve()
         else:
             rp = (Path("~/.miminions/workspaces").expanduser() / f"ws_{workspace.id}").resolve()
-
         result = init_workspace(rp)
         workspace.root_path = str(rp)
-
         click.echo(f"Initialized workspace files at: {workspace.root_path}")
         if result["created"]:
             click.echo(f"Created {len(result['created'])} file(s).")
@@ -128,13 +101,12 @@ def add_workspace(name, description, sample, init_files, root_path):
 
 @workspace_cli.command("show")
 @click.argument("workspace_id")
-@require_auth()
+@require_auth
 def show_workspace(workspace_id):
     """Show workspace details."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Find workspace by ID or name
     workspace = None
     for ws_id, ws in workspaces.items():
         if ws_id.startswith(workspace_id) or ws.name == workspace_id:
@@ -156,7 +128,6 @@ def show_workspace(workspace_id):
     click.echo(f"Updated: {workspace.updated_at}")
     click.echo()
     
-    # Show network summary
     summary = workspace.get_network_summary()
     click.echo("Network Summary:")
     click.echo(f"  Total Nodes: {summary['total_nodes']}")
@@ -166,7 +137,6 @@ def show_workspace(workspace_id):
     click.echo(f"  Inherited Rules: {summary['inherited_rules']}")
     click.echo()
     
-    # Show nodes
     if workspace.nodes:
         click.echo("Nodes:")
         for node in workspace.nodes.values():
@@ -179,7 +149,6 @@ def show_workspace(workspace_id):
                 click.echo(f"    State: {json.dumps(node.state, indent=6)[1:-1]}")
             click.echo()
     
-    # Show rules
     if workspace.rules:
         click.echo("Workspace Rules:")
         for rule in workspace.rules.values():
@@ -189,7 +158,6 @@ def show_workspace(workspace_id):
             click.echo(f"    Enabled: {rule.enabled}")
             click.echo()
     
-    # Show inherited rules
     if workspace.inherited_rules:
         click.echo("Inherited Rules:")
         for rule in workspace.inherited_rules.values():
@@ -199,7 +167,6 @@ def show_workspace(workspace_id):
             click.echo(f"    Enabled: {rule.enabled}")
             click.echo()
     
-    # Show current state
     if workspace.state:
         click.echo("Current State:")
         for key, value in workspace.state.items():
@@ -211,13 +178,12 @@ def show_workspace(workspace_id):
 @click.argument("workspace_id")
 @click.option("--name", help="New workspace name")
 @click.option("--description", help="New workspace description")
-@require_auth()
+@require_auth
 def update_workspace(workspace_id, name, description):
     """Update workspace details."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Find workspace by ID or name
     workspace = None
     for ws_id, ws in workspaces.items():
         if ws_id.startswith(workspace_id) or ws.name == workspace_id:
@@ -229,7 +195,6 @@ def update_workspace(workspace_id, name, description):
         return
     
     if name:
-        # Check if new name already exists
         for other_ws in workspaces.values():
             if other_ws.id != workspace.id and other_ws.name == name:
                 click.echo(f"A workspace named '{name}' already exists.")
@@ -248,13 +213,12 @@ def update_workspace(workspace_id, name, description):
 @workspace_cli.command("remove")
 @click.argument("workspace_id")
 @click.option("--force", is_flag=True, help="Force removal without confirmation")
-@require_auth()
+@require_auth
 def remove_workspace(workspace_id, force):
     """Remove a workspace."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Find workspace by ID or name
     workspace = None
     workspace_key = None
     for ws_id, ws in workspaces.items():
@@ -272,21 +236,19 @@ def remove_workspace(workspace_id, force):
     
     del workspaces[workspace_key]
     manager.save_workspaces(workspaces)
-    
     click.echo(f"Workspace '{workspace.name}' removed successfully.")
-    
-    
+
+
 @workspace_cli.command("set-state")
 @click.argument("workspace_id")
 @click.option("--key", required=True, help="State key")
 @click.option("--value", required=True, help="State value")
-@require_auth()
+@require_auth
 def set_state(workspace_id, key, value):
     """Set a state value in the workspace."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Find workspace
     workspace = None
     workspace_key = None
     for ws_id, ws in workspaces.items():
@@ -299,26 +261,22 @@ def set_state(workspace_id, key, value):
         click.echo(f"Workspace '{workspace_id}' not found.")
         return
     
-    # Try to parse value as JSON, fallback to string
     try:
         parsed_value = json.loads(value)
     except json.JSONDecodeError:
         parsed_value = value
     
     workspace.state[key] = parsed_value
-    
     workspace.updated_at = datetime.now(timezone.utc).isoformat()
     
     manager.save_workspaces(workspaces)
     click.echo(f"Set state '{key}' = '{parsed_value}' in workspace '{workspace.name}'.")
-    
+
+
 def _parse_json_or_shorthand(value: str | None, label: str) -> dict:
     if not value:
         return {}
-
     v = value.strip()
-
-    # Parse if it looks like JSON
     if v.startswith("{"):
         try:
             obj = json.loads(v)
@@ -327,10 +285,9 @@ def _parse_json_or_shorthand(value: str | None, label: str) -> dict:
         if not isinstance(obj, dict):
             raise click.ClickException(f"{label} must be a JSON object like {{...}}.")
         return obj
-
-    # Otherwise treat it as shorthand
     return {"type": v}
-    
+
+
 @workspace_cli.command("add-rule")
 @click.argument("workspace_id")
 @click.option("--name", required=True, help="Rule name")
@@ -339,13 +296,12 @@ def _parse_json_or_shorthand(value: str | None, label: str) -> dict:
 @click.option("--enabled/--disabled", default=True, show_default=True)
 @click.option("--condition", help='Condition JSON. Example: {"type":"state_equals","key":"x","value":1}')
 @click.option("--action", help='Action JSON. Example: {"type":"assign_task","message":"..."}')
-@require_auth()
+@require_auth
 def add_rule(workspace_id, name, description, priority, enabled, condition, action):
     """Add a rule to a workspace."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Find workspace
     workspace = None
     workspace_key = None
     for ws_id, ws in workspaces.items():
@@ -358,7 +314,6 @@ def add_rule(workspace_id, name, description, priority, enabled, condition, acti
         click.echo(f"Workspace '{workspace_id}' not found.")
         return
 
-    # Parse condition and action
     try:
         rule_condition = _parse_json_or_shorthand(condition, "condition")
         rule_action = _parse_json_or_shorthand(action, "action")
@@ -377,19 +332,18 @@ def add_rule(workspace_id, name, description, priority, enabled, condition, acti
     
     workspace.add_rule(rule)
     manager.save_workspaces(workspaces)
-    
     click.echo(f"Rule '{name}' added to workspace '{workspace.name}' with ID: {rule.id}")
-    
+
+
 @workspace_cli.command("remove-rule")
 @click.argument("workspace_id")
 @click.argument("rule_id_or_name")
-@require_auth()
+@require_auth
 def remove_rule(workspace_id, rule_id_or_name):
     """Remove a rule from a workspace."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
     
-    # Find workspace
     workspace = None
     workspace_key = None
     for ws_id, ws in workspaces.items():
@@ -402,7 +356,6 @@ def remove_rule(workspace_id, rule_id_or_name):
         click.echo(f"Workspace '{workspace_id}' not found.")
         return
     
-    # Find rule with partial ID or name match
     remove_id = None
     for rule_id, rule in workspace.rules.items():
         if rule_id.startswith(rule_id_or_name) or rule.name == rule_id_or_name:
@@ -419,9 +372,8 @@ def remove_rule(workspace_id, rule_id_or_name):
         return
     
     manager.save_workspaces(workspaces)
-    
     click.echo(f"Rule '{rule_id_or_name}' removed from workspace '{workspace.name}'.")
-        
+
 
 @workspace_cli.command("init-files")
 @click.argument("workspace_id")
@@ -431,13 +383,12 @@ def remove_rule(workspace_id, rule_id_or_name):
     default=None,
     help="Optional custom root path for this workspace folder."
 )
-@require_auth()
+@require_auth
 def init_files_workspace(workspace_id, custom_path):
     """Initialize prompt/memory/skills/sessions/data files for an existing workspace."""
     manager = get_workspace_manager()
     workspaces = manager.load_workspaces()
 
-    # Find workspace by ID or name
     workspace = None
     for ws_id, ws in workspaces.items():
         if ws_id.startswith(workspace_id) or ws.name == workspace_id:
@@ -455,12 +406,9 @@ def init_files_workspace(workspace_id, custom_path):
 
     result = init_workspace(rp)
     workspace.root_path = str(rp)
-
     manager.save_workspaces(workspaces)
-
     click.echo(f"Initialized workspace files for '{workspace.name}'")
     click.echo(f"Root path: {workspace.root_path}")
-
     if result["created"]:
         click.echo(f"Created {len(result['created'])} file(s).")
     if result["skipped"]:


### PR DESCRIPTION
## Description
Consolidates the duplicate `require_auth` functions scattered across CLI modules into a single shared location in `miminions/core/auth.py`, as flagged by Roland after PR #53 was merged.

## Changes Made
- Removed local `require_auth` no-op from `agent.py`, `task.py`, `workflow.py`, `workspace.py`, and `knowledge.py`
- All 5 modules now import `require_auth` from `miminions.core.auth`
- Removed unused `is_authenticated` and `is_public_access_enabled` imports from each module

## PR Information
| Field | Value |
|--------|--------|
| **Type** | Refactoring |
| **Priority** | Medium |
| **Breaking Change** | No |
| **Tests Added** | No |
| **Documentation Updated** | No |