### PR TITLE
Removing sentence-transformer to clean up dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Simplified user module design to be leaner and more focused
+- Replaced `sentence-transformers` with `fastembed` (ONNX Runtime) for `SQLiteMemory` embeddings, removing the PyTorch/CUDA dependency. Same `all-MiniLM-L6-v2` model and 384-dim output, so existing databases need no migration.
 
 ### Deprecated
 - None

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uv add miminions
 For full functionality, install optional dependencies:
 
 ```bash
-pip install miminions[full]
+pip install miminions[all]
 ```
 
 Or install individual components:

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -203,7 +203,7 @@ MiMinions/
 
 - **mcp** - Model Context Protocol client
 - **fastmcp** - Fast MCP utilities
-- **sentence-transformers** - Text embeddings
+- **fastembed** - Text embeddings (ONNX, no PyTorch/CUDA)
 - **sqlite-vec** - SQLite vector extension
 - **pdfplumber** - PDF text extraction
 - **click** - CLI framework

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -14,6 +14,7 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and 
 
 ### Changed
 - Simplified user module design to be leaner and more focused
+- Replaced `sentence-transformers` with `fastembed` (ONNX Runtime) for `SQLiteMemory` embeddings, removing the PyTorch/CUDA dependency. Same `all-MiniLM-L6-v2` model and 384-dim output, so existing databases need no migration.
 
 ### Removed
 - Complex user authentication and validation systems

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -54,13 +54,15 @@ When the session ends (e.g., typing `exit`), `MemoryDistiller` sends the `.jsonl
 
 For direct vector search, `SQLiteMemory` provides CRUD, keyword, and full-text search backed by `sqlite-vec`.
 
+Embeddings are generated locally with `fastembed` (the `all-MiniLM-L6-v2` model, 384-dim) — no PyTorch/CUDA required — so you store and query plain text:
+
 ```python
 from miminions.memory.sqlite import SQLiteMemory
 
 memory = SQLiteMemory("memory.db")
-memory.store("Python is a programming language", embedding=[0.1, 0.2, 0.3])
+memory.create("Python is a programming language", metadata={"tag": "tech"})
 
-results = memory.search(query_vector=[0.1, 0.2, 0.3], limit=5)
+results = memory.read("languages for coding", top_k=5)
 ```
 
 Requires the `sqlite` extra: `pip install miminions[sqlite]`

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: MiMinions
 site_description: An agentic framework with pydantic_ai, MCP server support and vector memory
-# site_url: https://docs.miminions.ai
+site_url: https://miminions.ai
 repo_url: https://github.com/MiMinions-ai/MiMinions
 repo_name: MiMinions-ai/MiMinions
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,13 +33,11 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
+  homepage: https://miminions.ai
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/MiMinions-ai/MiMinions
       name: MiMinions on GitHub
-    - icon: fontawesome/brands/x-twitter
-      link: https://x.com/miminions_ai
-      name: MiMinions on Twitter
 
 nav:
   - Home: index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,12 @@ miminions = "miminions.cli.main:main"
 
 [project.optional-dependencies]
 sqlite = [
-    "sentence-transformers>=2.2.0",
+    "fastembed>=0.3.0",
     "sqlite-vec>=0.1.0",
     "pysqlite3>=0.5.0",
 ]
 all = [
-    "sentence-transformers>=2.2.0",
+    "fastembed>=0.3.0",
     "sqlite-vec>=0.1.0",
     "pysqlite3>=0.5.0",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pydantic>=2.0.0
 pydantic-ai>=0.1.0
 openai>=2.14.0
 mcp>=1.0.0
-sentence-transformers>=2.2.0
+fastembed>=0.3.0
 numpy>=1.21.0
 
 # Document processing

--- a/src/miminions/memory/sqlite.py
+++ b/src/miminions/memory/sqlite.py
@@ -12,11 +12,17 @@ from pathlib import Path
 from typing import List, Dict, Any, Optional
 from .base_memory import BaseMemory
 from uuid import uuid4
-from sentence_transformers import SentenceTransformer
+from fastembed import TextEmbedding
 
 
 _DEFAULT_DB_DIR = Path(__file__).parent / ".data"
 _DEFAULT_DB_PATH = _DEFAULT_DB_DIR / "memory.db"
+
+# fastembed identifies models by their fully-qualified Hub name. Accept the
+# short sentence-transformers aliases callers may still pass.
+_MODEL_ALIASES = {
+    "all-MiniLM-L6-v2": "sentence-transformers/all-MiniLM-L6-v2",
+}
 
 
 def get_global_memory_db_path(create_dir: bool = True) -> str:
@@ -58,7 +64,7 @@ class SQLiteMemory(BaseMemory):
             self.db_path = str(user_path)
         
         self.dim = dim
-        self.encoder = SentenceTransformer(model_name)
+        self.encoder = TextEmbedding(_MODEL_ALIASES.get(model_name, model_name))
         self.conn = sqlite3.connect(self.db_path, check_same_thread=False)
         
         # Try to load sqlite-vec extension if available
@@ -75,7 +81,15 @@ class SQLiteMemory(BaseMemory):
         
         self._register_regex_function()
         self._setup_tables()
-    
+
+    def _embed(self, text: str) -> list:
+        """Encode a single string into a list of floats.
+
+        fastembed returns float64 arrays; _serialize_f32 truncates to float32
+        when packing for sqlite-vec, which is the expected storage format.
+        """
+        return list(self.encoder.embed([text]))[0].tolist()
+
     def _register_regex_function(self):
         """Register custom REGEXP function for SQLite."""
         def regexp(pattern, text):
@@ -108,7 +122,7 @@ class SQLiteMemory(BaseMemory):
     
     def create(self, text: str, metadata: Dict[str, Any] = None) -> str:
         id = str(uuid4())
-        vector = self.encoder.encode([text])[0].tolist()
+        vector = self._embed(text)
         
         self.conn.execute(
             "INSERT INTO knowledge (id, text, metadata) VALUES (?, ?, ?)",
@@ -122,7 +136,7 @@ class SQLiteMemory(BaseMemory):
         return id
     
     def read(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
-        query_vec = self.encoder.encode([query])[0].tolist()
+        query_vec = self._embed(query)
         
         cursor = self.conn.execute("""
             SELECT v.id, v.distance, k.text, k.metadata
@@ -149,7 +163,7 @@ class SQLiteMemory(BaseMemory):
         if not cursor.fetchone():
             return False
         
-        new_vec = self.encoder.encode([new_text])[0].tolist()
+        new_vec = self._embed(new_text)
         
         self.conn.execute(
             "UPDATE knowledge SET text = ? WHERE id = ?",


### PR DESCRIPTION
## Description

Replaced sentence-transformers (→ PyTorch + CUDA) with fastembed (ONNX Runtime, CPU, no torch) for local MiniLM embeddings.

Fixes # (issue)

## PR Information

| Field | Value |
|-------|-------|
| **Type** | Refactoring / Test |
| **Priority** | Low |
| **Breaking Change** | No |
| **Tests Added** | No |
| **Documentation Updated** | Yes |

## Changes Made

Import: SentenceTransformer → fastembed.TextEmbedding
Added _MODEL_ALIASES so the existing short name all-MiniLM-L6-v2 maps to fastembed's required Hub name sentence-transformers/all-MiniLM-L6-v2 (callers passing the old name keep working)
Added _embed() helper; the three encoder.encode(...) call sites now use it

## Testing

pip install fastembed pulled only onnxruntime/tokenizers/etc. — no torch.
Smoke test: same all-MiniLM-L6-v2 model, 384-dim output unchanged → no DB schema migration needed. Semantic search ranks correctly ("feline on a rug" → "the cat sat on the mat").
7/7 existing integration tests pass ([tests/integration/test_sqlite_memory.py](vscode-webview://1n9ls13icgk4016jfguiice1v7qpv7ch85k909afv1d24vava92n/tests/integration/test_sqlite_memory.py)).

## Additional Notes

Any other information reviewers should know.