### PR TITLE
Create default configuration for CLI

### DIFF
--- a/src/miminions/__main__.py
+++ b/src/miminions/__main__.py
@@ -1,5 +1,5 @@
-from miminions.cli import main
+from miminions.cli import cli
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/src/miminions/cli/chat.py
+++ b/src/miminions/cli/chat.py
@@ -12,7 +12,7 @@ from miminions.agent import create_minion
 from miminions.memory import MemoryDistiller
 from miminions.session.store import JsonlSessionStore
 from miminions.core.workspace import WorkspaceManager, ensure_workspace
-from miminions.cli.auth import get_config_dir
+from miminions.cli.auth import get_config, get_config_dir
 
 
 # ---------------------------------------------------------------------------
@@ -69,8 +69,8 @@ def chat_cli():
 @click.option(
     "--workspace",
     "workspace_ref",
-    required=True,
-    help="Workspace id or name.",
+    default=None,
+    help="Workspace id or name. Defaults to the configured default workspace.",
 )
 @click.option(
     "--session",
@@ -78,8 +78,14 @@ def chat_cli():
     default=None,
     help="Resume an existing session id (loads prior history for LLM context).",
 )
-def chat_command(workspace_ref: str, session_id: str | None) -> None:
+def chat_command(workspace_ref: str | None, session_id: str | None) -> None:
     """Start an interactive async chat session for a workspace."""
+    if not workspace_ref:
+        workspace_ref = get_config().get("default_workspace")
+        if not workspace_ref:
+            raise click.ClickException(
+                "No --workspace given and no default workspace configured."
+            )
     asyncio.run(_chat_loop(workspace_ref, session_id))
 
 

--- a/src/miminions/cli/main.py
+++ b/src/miminions/cli/main.py
@@ -4,7 +4,8 @@ MiMinions CLI - Main command line interface for the MiMinions package.
 
 import click
 from miminions import __version__
-from .auth import auth_cli
+from miminions.core.bootstrap import ensure_default_setup
+from .auth import auth_cli, get_config_dir
 from .agent import agent_cli
 from .task import task_cli
 from .workflow import workflow_cli
@@ -19,7 +20,10 @@ from .prompt import prompt_cli
 @click.version_option(version=__version__, prog_name="miminions")
 def cli():
     """MiMinions CLI - Manage AI agents, tasks, workflows and knowledge."""
-    pass
+    try:
+        ensure_default_setup(get_config_dir())
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 # Register command groups

--- a/src/miminions/core/bootstrap.py
+++ b/src/miminions/core/bootstrap.py
@@ -7,9 +7,10 @@ fall back to them when no explicit target is given.
 """
 
 import json
-from datetime import datetime, timezone
+import os
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 from miminions.core.workspace import WorkspaceManager, resolve_workspace
 from miminions.workspace_fs import init_workspace
@@ -18,20 +19,23 @@ DEFAULT_WORKSPACE_NAME = "default"
 DEFAULT_AGENT_ID = "default"
 
 
-def _load_json(path: Path) -> Dict[str, Any]:
+def _load_json(path: Path) -> dict[str, Any]:
     """Load a JSON file, returning {} if missing and failing clearly if corrupt."""
-    if not path.exists():
-        return {}
     try:
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8") as f:
             return json.load(f)
+    except FileNotFoundError:
+        return {}
     except json.JSONDecodeError as exc:
         raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
 
 
-def _save_json(path: Path, data: Dict[str, Any]) -> None:
-    with open(path, "w") as f:
+def _save_json(path: Path, data: dict[str, Any]) -> None:
+    """Write JSON atomically so an interrupted write can't leave a corrupt file."""
+    tmp = path.with_suffix(".tmp")
+    with open(tmp, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
+    os.replace(tmp, path)
 
 
 def _ensure_default_workspace(config_dir: Path) -> str:
@@ -51,6 +55,8 @@ def _ensure_default_workspace(config_dir: Path) -> str:
         root = (config_dir / "workspaces" / f"ws_{workspace.id}").resolve()
         workspace.root_path = str(root)
 
+    # init_workspace never overwrites existing files, so re-running only
+    # fills in whatever is missing.
     init_workspace(workspace.root_path)
     manager.save_workspaces(workspaces)
     return workspace.id
@@ -61,7 +67,7 @@ def _ensure_default_agent(config_dir: Path) -> str:
     agents_file = config_dir / "agents.json"
     agents = _load_json(agents_file)
     if agents:
-        return next(iter(agents))
+        return DEFAULT_AGENT_ID if DEFAULT_AGENT_ID in agents else next(iter(agents))
 
     agents[DEFAULT_AGENT_ID] = {
         "name": "default",
@@ -71,13 +77,13 @@ def _ensure_default_agent(config_dir: Path) -> str:
         "mode": "cli_extension",
         "status": "inactive",
         "goal": None,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "created_at": datetime.now(UTC).isoformat(),
     }
     _save_json(agents_file, agents)
     return DEFAULT_AGENT_ID
 
 
-def ensure_default_setup(config_dir: Path) -> Dict[str, Any]:
+def ensure_default_setup(config_dir: Path) -> dict[str, Any]:
     """
     Ensure a new user has a working default setup.
 
@@ -85,7 +91,6 @@ def ensure_default_setup(config_dir: Path) -> Dict[str, Any]:
     sessions, and data templates included), seeds a default agent, and records
     both in config.json. Later runs cost a single config read.
     """
-    config_dir = Path(config_dir)
     config_file = config_dir / "config.json"
     config = _load_json(config_file)
 

--- a/src/miminions/core/bootstrap.py
+++ b/src/miminions/core/bootstrap.py
@@ -1,0 +1,99 @@
+"""
+First-run bootstrap for MiMinions.
+
+Creates a default workspace (with prompt, skill, and memory templates),
+seeds a default agent, and records both in config.json so commands can
+fall back to them when no explicit target is given.
+"""
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict
+
+from miminions.core.workspace import WorkspaceManager, resolve_workspace
+from miminions.workspace_fs import init_workspace
+
+DEFAULT_WORKSPACE_NAME = "default"
+DEFAULT_AGENT_ID = "default"
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    """Load a JSON file, returning {} if missing and failing clearly if corrupt."""
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in {path}: {exc}") from exc
+
+
+def _save_json(path: Path, data: Dict[str, Any]) -> None:
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _ensure_default_workspace(config_dir: Path) -> str:
+    """Create and initialize the default workspace if needed; return its id."""
+    manager = WorkspaceManager(config_dir)
+    workspaces = manager.load_workspaces()
+
+    workspace = resolve_workspace(workspaces, DEFAULT_WORKSPACE_NAME)
+    if workspace is None:
+        workspace = manager.create_workspace(
+            DEFAULT_WORKSPACE_NAME,
+            description="Default workspace created on first run.",
+        )
+        workspaces[workspace.id] = workspace
+
+    if not workspace.root_path:
+        root = (config_dir / "workspaces" / f"ws_{workspace.id}").resolve()
+        workspace.root_path = str(root)
+
+    init_workspace(workspace.root_path)
+    manager.save_workspaces(workspaces)
+    return workspace.id
+
+
+def _ensure_default_agent(config_dir: Path) -> str:
+    """Seed a default agent record if no agents exist; return the default agent id."""
+    agents_file = config_dir / "agents.json"
+    agents = _load_json(agents_file)
+    if agents:
+        return next(iter(agents))
+
+    agents[DEFAULT_AGENT_ID] = {
+        "name": "default",
+        "description": "Default MiMinions agent created on first run.",
+        "type": "assistant",
+        "base_agent": "miminions.agent.Minion",
+        "mode": "cli_extension",
+        "status": "inactive",
+        "goal": None,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    }
+    _save_json(agents_file, agents)
+    return DEFAULT_AGENT_ID
+
+
+def ensure_default_setup(config_dir: Path) -> Dict[str, Any]:
+    """
+    Ensure a new user has a working default setup.
+
+    On first run this creates the default workspace (prompt, skills, memory,
+    sessions, and data templates included), seeds a default agent, and records
+    both in config.json. Later runs cost a single config read.
+    """
+    config_dir = Path(config_dir)
+    config_file = config_dir / "config.json"
+    config = _load_json(config_file)
+
+    if config.get("default_workspace"):
+        return config
+
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config["default_workspace"] = _ensure_default_workspace(config_dir)
+    config["default_agent"] = _ensure_default_agent(config_dir)
+    _save_json(config_file, config)
+    return config

--- a/tests/integration/test_distiller.py
+++ b/tests/integration/test_distiller.py
@@ -80,7 +80,7 @@ def test_distill_session_accepts_partial_llm_output_with_permissive_defaults(tmp
 
 def test_distill_session_promotes_history_and_workspace_memory(tmp_path, monkeypatch):
     _FakeSQLiteMemory.created = []
-    monkeypatch.setattr("miminions.memory.distiller.SQLiteMemory", _FakeSQLiteMemory)
+    monkeypatch.setattr("miminions.memory.sqlite.SQLiteMemory", _FakeSQLiteMemory)
 
     session_id = append_transcript(tmp_path)
 
@@ -120,7 +120,7 @@ def test_distill_session_promotes_history_and_workspace_memory(tmp_path, monkeyp
 
 def test_distill_session_stores_global_insights_as_plain_text(tmp_path, monkeypatch):
     _FakeSQLiteMemory.created = []
-    monkeypatch.setattr("miminions.memory.distiller.SQLiteMemory", _FakeSQLiteMemory)
+    monkeypatch.setattr("miminions.memory.sqlite.SQLiteMemory", _FakeSQLiteMemory)
 
     session_id = append_transcript(tmp_path)
 
@@ -169,7 +169,7 @@ def test_distill_session_continues_when_sqlite_is_unavailable(tmp_path, monkeypa
         def __init__(self, _db_path: str):
             raise RuntimeError("sqlite unavailable")
 
-    monkeypatch.setattr("miminions.memory.distiller.SQLiteMemory", _BrokenSQLiteMemory)
+    monkeypatch.setattr("miminions.memory.sqlite.SQLiteMemory", _BrokenSQLiteMemory)
     session_id = append_transcript(tmp_path)
 
     distiller = MemoryDistiller(

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -4,6 +4,8 @@ Tests for the first-run default setup bootstrap.
 
 import json
 
+import pytest
+
 from miminions.core.bootstrap import ensure_default_setup
 
 
@@ -48,6 +50,13 @@ def test_second_run_is_noop(temp_config_dir):
 
     assert second == first
     assert user_md.read_text() == "# customized by user\n"
+
+
+def test_corrupt_config_raises(temp_config_dir):
+    (temp_config_dir / "config.json").write_text("{ not valid json")
+
+    with pytest.raises(ValueError):
+        ensure_default_setup(temp_config_dir)
 
 
 def test_existing_agents_are_preserved(temp_config_dir):

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,61 @@
+"""
+Tests for the first-run default setup bootstrap.
+"""
+
+import json
+
+from miminions.core.bootstrap import ensure_default_setup
+
+
+def _workspace_root(config_dir, config):
+    return config_dir / "workspaces" / f"ws_{config['default_workspace']}"
+
+
+def test_first_run_creates_defaults(temp_config_dir):
+    config = ensure_default_setup(temp_config_dir)
+
+    assert config["default_workspace"]
+    assert config["default_agent"] == "default"
+
+    saved = json.loads((temp_config_dir / "config.json").read_text())
+    assert saved == config
+
+    root = _workspace_root(temp_config_dir, config)
+    assert (root / "prompt" / "AGENTS.md").exists()
+    assert (root / "prompt" / "USER.md").exists()
+    assert (root / "prompt" / "TOOLS.md").exists()
+    assert (root / "prompt" / "IDENTITY.md").exists()
+    assert (root / "skills" / "core" / "SKILL.md").exists()
+    assert (root / "memory" / "MEMORY.md").exists()
+    assert (root / "sessions").is_dir()
+    assert (root / "data").is_dir()
+
+    agents = json.loads((temp_config_dir / "agents.json").read_text())
+    assert agents["default"]["base_agent"] == "miminions.agent.Minion"
+
+    workspaces = json.loads((temp_config_dir / "workspaces.json").read_text())
+    assert config["default_workspace"] in workspaces
+    assert workspaces[config["default_workspace"]]["name"] == "default"
+
+
+def test_second_run_is_noop(temp_config_dir):
+    first = ensure_default_setup(temp_config_dir)
+
+    user_md = _workspace_root(temp_config_dir, first) / "prompt" / "USER.md"
+    user_md.write_text("# customized by user\n")
+
+    second = ensure_default_setup(temp_config_dir)
+
+    assert second == first
+    assert user_md.read_text() == "# customized by user\n"
+
+
+def test_existing_agents_are_preserved(temp_config_dir):
+    agents_file = temp_config_dir / "agents.json"
+    agents_file.write_text(json.dumps({"mybot": {"name": "mybot"}}))
+
+    config = ensure_default_setup(temp_config_dir)
+
+    assert config["default_agent"] == "mybot"
+    agents = json.loads(agents_file.read_text())
+    assert list(agents) == ["mybot"]


### PR DESCRIPTION
Description

This pull request introduces a first-run bootstrap mechanism to ensure new users have a working default setup, including a default workspace and agent. It also updates the CLI to leverage this setup, improves workspace selection logic, and adds comprehensive tests for the bootstrap process. Additionally, it fixes some test imports for memory mocking.

Fixes # (issue)

## PR Information

| Field | Value |
|-------|-------|
| **Type** | Bug fix / New feature / Documentation / Refactoring / Test |
| **Priority** | Low / Medium / High / Critical |
| **Breaking Change** | Yes / No |
| **Tests Added** | Yes / No |
| **Documentation Updated** | Yes / No |

## Changes Made

Describe the main changes in this PR:

## Testing

Describe how you tested these changes:

## Additional Notes

Any other information reviewers should know.