### PR TITLE
Feature/agent cli execution

### DIFF
--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -2,9 +2,6 @@
 
 import asyncio
 import inspect
-import shlex
-import subprocess
-import sys
 import time
 from typing import Any, Callable, Dict, List, Optional
 from pathlib import Path
@@ -14,6 +11,11 @@ from mcp import StdioServerParameters
 
 from miminions.agent.provider import ModelFactory
 from ..tools import GenericTool
+from ..tools.default import (
+    CLI_RUN_COMMAND_DESCRIPTION,
+    CLI_RUN_COMMAND_NAME,
+    cli_run_command,
+)
 from ..tools.mcp_adapter import MCPToolAdapter
 from ..memory.base_memory import BaseMemory
 from ..utils.chunker import TextChunker
@@ -114,7 +116,11 @@ class Minion:
         self._pydantic_ai_tools: List[Tool] = []
         self._last_messages: List[Any] = []
 
-        self._register_cli_tools()
+        self.register_tool(
+            CLI_RUN_COMMAND_NAME,
+            CLI_RUN_COMMAND_DESCRIPTION,
+            cli_run_command,
+        )
         
         if self._memory:
             self._register_memory_tools()
@@ -299,48 +305,6 @@ class Minion:
     def handle_tool_execution_request(self, request: ToolExecutionRequest) -> ToolExecutionResult:
         """Execute from a ToolExecutionRequest (for LLM integration)."""
         return self.execute(request.tool_name, request.arguments)
-
-    # cli tools
-    def _register_cli_tools(self) -> None:
-        """Register local command execution tools."""
-        self.register_tool(
-            "cli_run_command",
-            "Execute a CLI command without a shell and return stdout, stderr, and return code",
-            self._cli_run_command,
-        )
-
-    def _cli_run_command(self, command: str, timeout: int = 30) -> Dict[str, Any]:
-        """Run a command with subprocess using shell=False."""
-        if not command or not command.strip():
-            raise ValueError("Command must not be empty")
-        if timeout <= 0:
-            raise ValueError("Timeout must be greater than zero")
-
-        try:
-            args = shlex.split(command, posix=(sys.platform != "win32"))
-        except ValueError as exc:
-            raise ValueError(f"Could not parse command: {exc}") from exc
-
-        if not args:
-            raise ValueError("Command must not be empty")
-
-        try:
-            completed = subprocess.run(
-                args,
-                shell=False,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise TimeoutError(f"Command timed out after {timeout} seconds") from exc
-
-        return {
-            "command": command,
-            "returncode": completed.returncode,
-            "stdout": completed.stdout,
-            "stderr": completed.stderr,
-        }
 
     # memory
     def _register_memory_tools(self) -> None:

--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -2,6 +2,9 @@
 
 import asyncio
 import inspect
+import shlex
+import subprocess
+import sys
 import time
 from typing import Any, Callable, Dict, List, Optional
 from pathlib import Path
@@ -110,6 +113,8 @@ class Minion:
         self._pydantic_ai_agent: Optional[Agent] = None
         self._pydantic_ai_tools: List[Tool] = []
         self._last_messages: List[Any] = []
+
+        self._register_cli_tools()
         
         if self._memory:
             self._register_memory_tools()
@@ -294,6 +299,48 @@ class Minion:
     def handle_tool_execution_request(self, request: ToolExecutionRequest) -> ToolExecutionResult:
         """Execute from a ToolExecutionRequest (for LLM integration)."""
         return self.execute(request.tool_name, request.arguments)
+
+    # cli tools
+    def _register_cli_tools(self) -> None:
+        """Register local command execution tools."""
+        self.register_tool(
+            "cli_run_command",
+            "Execute a CLI command without a shell and return stdout, stderr, and return code",
+            self._cli_run_command,
+        )
+
+    def _cli_run_command(self, command: str, timeout: int = 30) -> Dict[str, Any]:
+        """Run a command with subprocess using shell=False."""
+        if not command or not command.strip():
+            raise ValueError("Command must not be empty")
+        if timeout <= 0:
+            raise ValueError("Timeout must be greater than zero")
+
+        try:
+            args = shlex.split(command, posix=(sys.platform != "win32"))
+        except ValueError as exc:
+            raise ValueError(f"Could not parse command: {exc}") from exc
+
+        if not args:
+            raise ValueError("Command must not be empty")
+
+        try:
+            completed = subprocess.run(
+                args,
+                shell=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError(f"Command timed out after {timeout} seconds") from exc
+
+        return {
+            "command": command,
+            "returncode": completed.returncode,
+            "stdout": completed.stdout,
+            "stderr": completed.stderr,
+        }
 
     # memory
     def _register_memory_tools(self) -> None:

--- a/src/miminions/tools/default.py
+++ b/src/miminions/tools/default.py
@@ -1,0 +1,46 @@
+"""Built-in tools available to every Minion."""
+
+import shlex
+import subprocess
+import sys
+from typing import Any, Dict
+
+
+CLI_RUN_COMMAND_NAME = "cli_run_command"
+CLI_RUN_COMMAND_DESCRIPTION = (
+    "Execute a CLI command without a shell and return stdout, stderr, and return code"
+)
+
+
+def cli_run_command(command: str, timeout: int = 30) -> Dict[str, Any]:
+    """Run a command with subprocess using shell=False."""
+    if not command or not command.strip():
+        raise ValueError("Command must not be empty")
+    if timeout <= 0:
+        raise ValueError("Timeout must be greater than zero")
+
+    try:
+        args = shlex.split(command, posix=(sys.platform != "win32"))
+    except ValueError as exc:
+        raise ValueError(f"Could not parse command: {exc}") from exc
+
+    if not args:
+        raise ValueError("Command must not be empty")
+
+    try:
+        completed = subprocess.run(
+            args,
+            shell=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError(f"Command timed out after {timeout} seconds") from exc
+
+    return {
+        "command": command,
+        "returncode": completed.returncode,
+        "stdout": completed.stdout,
+        "stderr": completed.stderr,
+    }

--- a/tests/integration/test_cli_agent.py
+++ b/tests/integration/test_cli_agent.py
@@ -6,6 +6,7 @@ import pytest
 import json
 import tempfile
 import os
+import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 from click.testing import CliRunner
@@ -345,6 +346,7 @@ class TestAgentCLI:
 
             assert result.exit_code == 0
             assert "Tools for 'test_agent':" in result.output
+            assert "cli_run_command" in result.output
             assert "cli_echo" in result.output
             assert "cli_add" in result.output
 
@@ -394,6 +396,33 @@ class TestAgentCLI:
             assert "Tool: cli_add" in result.output
             assert "Status: success" in result.output
             assert "Result: 5" in result.output
+
+    def test_tool_run_cli_command_success(self):
+        """Test running the default command execution tool through the CLI."""
+        existing_agents = {
+            "test_agent": {
+                "name": "Test Agent",
+                "description": "A test agent",
+                "type": "general",
+                "status": "inactive",
+            }
+        }
+        arguments = json.dumps({"command": f"{sys.executable} --version"})
+
+        with patch('miminions.core.auth.is_authenticated', return_value=True):
+            with patch('miminions.cli.agent.load_agents') as mock_load:
+                mock_load.return_value = existing_agents
+
+                result = self.runner.invoke(
+                    agent_cli,
+                    ['tool-run', 'test_agent', 'cli_run_command', '--arguments', arguments]
+                )
+
+            assert result.exit_code == 0
+            assert "Tool: cli_run_command" in result.output
+            assert "Status: success" in result.output
+            assert "'returncode': 0" in result.output
+            assert "Python" in result.output
 
     def test_tool_run_invalid_json(self):
         """Test running a tool with invalid JSON input."""

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,8 +1,10 @@
 """Agent Test Suite - Core functionality tests."""
 
 import asyncio
+import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import patch
 
 from miminions.agent import (
     Minion,
@@ -26,8 +28,9 @@ async def test_agent_creation():
     assert agent.description == "A test agent"
     
     state = agent.get_state()
-    assert state.tool_count == 0
+    assert state.tool_count == 1
     assert state.has_memory == False
+    assert "cli_run_command" in agent.list_tools()
     
     await agent.cleanup()
     print("PASSED")
@@ -132,6 +135,80 @@ async def test_error_handling():
     return True
 
 
+async def test_cli_run_command_tool_success():
+    """Test successful CLI command execution."""
+    print("test_cli_run_command_tool_success")
+    agent = create_minion("TestAgent")
+
+    result = agent.execute(
+        "cli_run_command",
+        arguments={"command": f"{sys.executable} --version"},
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.result["returncode"] == 0
+    assert "Python" in result.result["stdout"]
+    assert result.result["stderr"] == ""
+
+    await agent.cleanup()
+    print("PASSED")
+    return True
+
+
+async def test_cli_run_command_tool_nonzero_exit():
+    """Test command failures return a nonzero return code without raising."""
+    print("test_cli_run_command_tool_nonzero_exit")
+    agent = create_minion("TestAgent")
+
+    result = agent.execute(
+        "cli_run_command",
+        arguments={"command": f"{sys.executable} --definitely-not-a-python-option"},
+    )
+
+    assert result.status == ExecutionStatus.SUCCESS
+    assert result.result["returncode"] != 0
+    assert "definitely-not-a-python-option" in result.result["stderr"]
+
+    await agent.cleanup()
+    print("PASSED")
+    return True
+
+
+async def test_cli_run_command_tool_empty_command_error():
+    """Test empty commands are reported as tool errors."""
+    print("test_cli_run_command_tool_empty_command_error")
+    agent = create_minion("TestAgent")
+
+    result = agent.execute("cli_run_command", arguments={"command": "   "})
+
+    assert result.status == ExecutionStatus.ERROR
+    assert "must not be empty" in result.error
+
+    await agent.cleanup()
+    print("PASSED")
+    return True
+
+
+async def test_cli_run_command_tool_timeout_error():
+    """Test command timeouts are reported as tool errors."""
+    print("test_cli_run_command_tool_timeout_error")
+    agent = create_minion("TestAgent")
+
+    with patch("miminions.agent.agent.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(["python"], timeout=1)
+        result = agent.execute(
+            "cli_run_command",
+            arguments={"command": f"{sys.executable} --version", "timeout": 1},
+        )
+
+    assert result.status == ExecutionStatus.ERROR
+    assert "timed out after 1 seconds" in result.error
+
+    await agent.cleanup()
+    print("PASSED")
+    return True
+
+
 async def test_tool_schema_json():
     """Test JSON schema generation."""
     print("test_tool_schema_json")
@@ -143,9 +220,9 @@ async def test_tool_schema_json():
     agent.register_tool("search", "Search for items", search)
     
     schemas = agent.get_tools_schema()
-    assert len(schemas) == 1
+    assert len(schemas) == 2
     
-    schema = schemas[0]
+    schema = next(s for s in schemas if s["name"] == "search")
     assert schema["name"] == "search"
     assert "parameters" in schema
     assert "query" in schema["parameters"]["properties"]
@@ -185,6 +262,10 @@ async def main():
         test_tool_registration,
         test_tool_execution,
         test_error_handling,
+        test_cli_run_command_tool_success,
+        test_cli_run_command_tool_nonzero_exit,
+        test_cli_run_command_tool_empty_command_error,
+        test_cli_run_command_tool_timeout_error,
         test_tool_schema_json,
         test_tool_management,
     ]

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -194,7 +194,7 @@ async def test_cli_run_command_tool_timeout_error():
     print("test_cli_run_command_tool_timeout_error")
     agent = create_minion("TestAgent")
 
-    with patch("miminions.agent.agent.subprocess.run") as mock_run:
+    with patch("miminions.tools.default.subprocess.run") as mock_run:
         mock_run.side_effect = subprocess.TimeoutExpired(["python"], timeout=1)
         result = agent.execute(
             "cli_run_command",

--- a/tests/unit/test_agent.py
+++ b/tests/unit/test_agent.py
@@ -1,10 +1,8 @@
 """Agent Test Suite - Core functionality tests."""
 
 import asyncio
-import subprocess
 import sys
 from pathlib import Path
-from unittest.mock import patch
 
 from miminions.agent import (
     Minion,
@@ -135,80 +133,6 @@ async def test_error_handling():
     return True
 
 
-async def test_cli_run_command_tool_success():
-    """Test successful CLI command execution."""
-    print("test_cli_run_command_tool_success")
-    agent = create_minion("TestAgent")
-
-    result = agent.execute(
-        "cli_run_command",
-        arguments={"command": f"{sys.executable} --version"},
-    )
-
-    assert result.status == ExecutionStatus.SUCCESS
-    assert result.result["returncode"] == 0
-    assert "Python" in result.result["stdout"]
-    assert result.result["stderr"] == ""
-
-    await agent.cleanup()
-    print("PASSED")
-    return True
-
-
-async def test_cli_run_command_tool_nonzero_exit():
-    """Test command failures return a nonzero return code without raising."""
-    print("test_cli_run_command_tool_nonzero_exit")
-    agent = create_minion("TestAgent")
-
-    result = agent.execute(
-        "cli_run_command",
-        arguments={"command": f"{sys.executable} --definitely-not-a-python-option"},
-    )
-
-    assert result.status == ExecutionStatus.SUCCESS
-    assert result.result["returncode"] != 0
-    assert "definitely-not-a-python-option" in result.result["stderr"]
-
-    await agent.cleanup()
-    print("PASSED")
-    return True
-
-
-async def test_cli_run_command_tool_empty_command_error():
-    """Test empty commands are reported as tool errors."""
-    print("test_cli_run_command_tool_empty_command_error")
-    agent = create_minion("TestAgent")
-
-    result = agent.execute("cli_run_command", arguments={"command": "   "})
-
-    assert result.status == ExecutionStatus.ERROR
-    assert "must not be empty" in result.error
-
-    await agent.cleanup()
-    print("PASSED")
-    return True
-
-
-async def test_cli_run_command_tool_timeout_error():
-    """Test command timeouts are reported as tool errors."""
-    print("test_cli_run_command_tool_timeout_error")
-    agent = create_minion("TestAgent")
-
-    with patch("miminions.tools.default.subprocess.run") as mock_run:
-        mock_run.side_effect = subprocess.TimeoutExpired(["python"], timeout=1)
-        result = agent.execute(
-            "cli_run_command",
-            arguments={"command": f"{sys.executable} --version", "timeout": 1},
-        )
-
-    assert result.status == ExecutionStatus.ERROR
-    assert "timed out after 1 seconds" in result.error
-
-    await agent.cleanup()
-    print("PASSED")
-    return True
-
-
 async def test_tool_schema_json():
     """Test JSON schema generation."""
     print("test_tool_schema_json")
@@ -262,10 +186,6 @@ async def main():
         test_tool_registration,
         test_tool_execution,
         test_error_handling,
-        test_cli_run_command_tool_success,
-        test_cli_run_command_tool_nonzero_exit,
-        test_cli_run_command_tool_empty_command_error,
-        test_cli_run_command_tool_timeout_error,
         test_tool_schema_json,
         test_tool_management,
     ]

--- a/tests/unit/test_default_tools.py
+++ b/tests/unit/test_default_tools.py
@@ -1,0 +1,43 @@
+"""Tests for built-in Minion tools."""
+
+import subprocess
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from miminions.tools.default import cli_run_command
+
+
+def test_cli_run_command_success():
+    """A successful command returns its output and zero exit code."""
+    result = cli_run_command(f"{sys.executable} --version")
+
+    assert result["returncode"] == 0
+    assert "Python" in result["stdout"]
+    assert result["stderr"] == ""
+
+
+def test_cli_run_command_nonzero_exit():
+    """A failed command returns its nonzero exit code and stderr."""
+    result = cli_run_command(
+        f"{sys.executable} --definitely-not-a-python-option"
+    )
+
+    assert result["returncode"] != 0
+    assert "definitely-not-a-python-option" in result["stderr"]
+
+
+def test_cli_run_command_rejects_empty_command():
+    """An empty command is rejected before creating a subprocess."""
+    with pytest.raises(ValueError, match="Command must not be empty"):
+        cli_run_command("   ")
+
+
+def test_cli_run_command_timeout():
+    """A subprocess timeout is exposed as a clear timeout error."""
+    with patch("miminions.tools.default.subprocess.run") as mock_run:
+        mock_run.side_effect = subprocess.TimeoutExpired(["python"], timeout=1)
+
+        with pytest.raises(TimeoutError, match="timed out after 1 seconds"):
+            cli_run_command(f"{sys.executable} --version", timeout=1)


### PR DESCRIPTION
## Description

Adds a core tool for executing CLI commands. Gives agents a simple command execution capability, captures output, and enforces a timeout.

## PR Information

| Field | Value |
|-------|-------|
| **Type** | New feature |
| **Priority** | Medium |
| **Breaking Change** | No |
| **Tests Added** | Yes |
| **Documentation Updated** | No |

## Changes Made

- Registered a new default core Minion tool: `cli_run_command`.
- Returns structured command results including `command`, `returncode`, `stdout`, and `stderr`.
- Surfaces empty commands, parse failures, invalid timeouts, and timeouts as tool errors.
- Updated existing agent schema expectations now that Minions include one default tool.
- Added unit and CLI integration coverage for the new command tool.

## Testing

Ran the focused test suite:

```bash
python -m pytest tests\unit\test_agent.py tests\integration\test_cli_agent.py
```

## Additional Notes

The command runner intentionally uses shell=False, so shell features like pipes, redirects, chained commands, and shell variable expansion are not supported by this version.