### PR TITLE
fix(ci): resolve pytest collection errors (pydantic-ai + stray chat_test.py)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.0.0",
     "pydantic>=2.0.0",
-    "pydantic-ai>=0.1.0",
+    "pydantic-ai>=1.0.0,<2.0.0",
     "openai>=2.14.0",
     "mcp>=1.23.0",
     "numpy>=1.21.0",
@@ -47,4 +47,5 @@ cli-build = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies
 pydantic>=2.0.0
-pydantic-ai>=0.1.0
+pydantic-ai>=1.0.0,<2.0.0
 openai>=2.14.0
 mcp>=1.0.0
 fastembed>=0.3.0

--- a/src/miminions/agent/__init__.py
+++ b/src/miminions/agent/__init__.py
@@ -30,8 +30,8 @@ Example:
     print(reply)  # "The answer is 10."
 
     # To use a different model:
-    from pydantic_ai.models.openai import OpenAIModel
-    agent = create_minion(name="MyAgent", model=OpenAIModel("gpt-4o"))
+    from pydantic_ai.models.openai import OpenAIChatModel
+    agent = create_minion(name="MyAgent", model=OpenAIChatModel("gpt-4o"))
 """
 
 from __future__ import annotations

--- a/src/miminions/agent/provider.py
+++ b/src/miminions/agent/provider.py
@@ -1,5 +1,5 @@
 import os
-from pydantic_ai.models.openai import OpenAIModel
+from pydantic_ai.models.openai import OpenAIChatModel
 from pydantic_ai.providers.openai import OpenAIProvider
 from pydantic_ai.models.gemini import GeminiModel
 from pydantic_ai.models.anthropic import AnthropicModel
@@ -19,11 +19,11 @@ class ModelFactory:
                 base_url="https://openrouter.ai/api/v1",
                 api_key=os.environ.get("OPENROUTER_API_KEY", ""),
             )
-            return OpenAIModel(model_name, provider=provider)
+            return OpenAIChatModel(model_name, provider=provider)
             
         elif provider_name == "openai":
             model_name = model_name or "gpt-4o"
-            return OpenAIModel(model_name)
+            return OpenAIChatModel(model_name)
             
         elif provider_name == "anthropic":
             model_name = model_name or "claude-3-5-sonnet-latest"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,18 @@
 Pytest configuration for MiMinions CLI tests.
 """
 
+import os
 import sys
 import pytest
 import tempfile
 import shutil
 from pathlib import Path
+
+# Provide placeholder credentials so model clients (OpenAI/OpenRouter/etc.)
+# can be constructed during tests without real secrets. Newer openai SDKs
+# reject empty api keys at client construction; tests never make live calls.
+for _key in ("OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GEMINI_API_KEY"):
+    os.environ.setdefault(_key, "test-placeholder")
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"


### PR DESCRIPTION
## Problem
CI `pytest` failed with 11 collection errors:

- **10 × ImportError** `cannot import name 'OpenAIModel' from 'pydantic_ai.models.openai'` — `pydantic-ai` was unpinned (`>=0.1.0`), so CI installed a newer version that **renamed** `OpenAIModel` → `OpenAIChatModel` and dropped the old alias. Local had an older cached version, hiding the break.
- **1 × FileNotFoundError** on `.env` — the root-level `chat_test.py` is a manual interactive script (not a real test) that reads `.env` at import time. Pytest collected it by name and crashed where no `.env` exists.

## Fix
- `agent/provider.py`: import and use `OpenAIChatModel` (the current name); updated the docstring example in `agent/__init__.py` to match.
- Pin `pydantic-ai>=1.0.0,<2.0.0` in `pyproject.toml` and `requirements.txt` so CI and local stay in sync.
- Add `testpaths = ["tests"]` to pytest config so collection is scoped to `tests/` and ignores the root `chat_test.py`.

## Verification
- `ruff check --line-length=127 src tests` → clean
- `pytest` → **439 passed**, 0 collection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)