### PR TITLE
Agent runtime features

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,11 +5,29 @@ All notable changes to MiMinions are documented here.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and the project adheres to [Semantic Versioning](https://semver.org/).
 
 !!! tip "Current version"
-    The latest published release is **0.2.2** (requires Python &ge; 3.12). Install it with `pip install miminions`, or `pip install miminions[sqlite]` to add SQLite vector memory. See [Getting Started](getting-started.md) for the full matrix.
+    The latest published release is **0.3.0** (requires Python &ge; 3.12). Install it with `pip install miminions`, or `pip install miminions[sqlite]` to add SQLite vector memory. See [Getting Started](getting-started.md) for the full matrix.
 
 ## [Unreleased]
 
-Work in progress toward the next release. Everything below is on `main` but not yet cut into a versioned tag.
+Work in progress toward the next release.
+
+### Added
+
+- **Streaming replies.** `Minion.run_stream()` yields the LLM reply as incremental text deltas; the CLI `chat` loop now streams every reply to the terminal. See [Agent](modules/agent.md#streaming-replies).
+- **Retries, timeouts, and observability hooks.** `create_minion` accepts `request_timeout` (per-HTTP-request, default 60 s), `max_retries` (default 2) with exponential backoff on transient provider errors (429/5xx, connection failures), and optional `on_tool_call` / `on_turn_end` callbacks. `miminions chat start --verbose` uses them to show tool calls, token usage, and latency per turn.
+- **Message-history trimming.** `trim_message_history` caps the LLM context for long chat sessions at 40 messages, cutting only at user-turn boundaries so tool call/return pairs are never split; the on-disk transcript stays complete.
+- **Workspace schema versioning.** Persisted workspace records carry a `schema_version` field (currently 1) with a migration hook at load time; unversioned records are treated as v1 and stamped on the next save.
+- **`SQLiteMemory` as a context manager.** `with SQLiteMemory(...) as mem:` closes the connection automatically.
+- **Centralized path resolution** (`miminions.core.paths`). All persistent state resolves through `get_config_dir()`, honoring a new `MIMINIONS_HOME` environment variable to relocate `~/.miminions`. `get_global_memory_db_path` moved here (still re-exported from `miminions.memory.sqlite`).
+
+### Changed
+
+- **Atomic JSON persistence.** Shared `load_json` / `save_json` helpers (`miminions.core.persistence`) write all CLI/JSON stores atomically and fail loudly on corrupt files.
+- **Fail-fast OpenRouter key check.** With the default `openrouter` provider, a missing `OPENROUTER_API_KEY` now raises `ValueError` at `create_minion(...)` construction instead of failing later at call time.
+- `miminions agent add` derives unique agent ids: a name collision gets a `_2`, `_3`, … suffix instead of an error, and `created_at` is now a real UTC timestamp.
+- Chat errors preserve any partially streamed reply in the session transcript alongside the `[error]` marker.
+
+## [0.3.0] - 2026-07-02
 
 ### Added
 
@@ -37,8 +55,6 @@ Work in progress toward the next release. Everything below is on `main` but not 
 
 ## [0.2.2] - 2026-04-02
 
-Current published release on PyPI.
-
 ### Added
 
 - Agent layer built on `pydantic_ai`: `create_minion` / `Minion` with a tool registry, optional vector memory (auto-registering seven memory + ingestion tools), and an async `run()` reasoning loop.
@@ -65,8 +81,9 @@ Initial release.
 
 | Version | Notes |
 |---------|-------|
-| **Unreleased** | CLI, three-tier memory + distiller, workspaces, context builder, MCP loading, gateway building blocks; `fastembed` embeddings |
-| **0.2.2** | Current published release &mdash; agent, vector memory, tools, local data |
+| **Unreleased** | Streaming replies, retries + timeouts + hooks, history trimming, workspace schema versioning, `MIMINIONS_HOME`, atomic JSON persistence |
+| **0.3.0** | Current published release &mdash; CLI, three-tier memory + distiller, workspaces, context builder, MCP loading, gateway building blocks; `fastembed` embeddings |
+| **0.2.2** | Agent, vector memory, tools, local data |
 | **0.1.0** | Initial release with core functionality |
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -54,9 +54,12 @@ Everything you need to know about MiMinions.
 
     MiMinions takes a pragmatic, local-first approach to safety:
 
-    - **Sign-in gating on the CLI.** Commands are wrapped with `require_auth`, so
-      they refuse to run until you sign in with `miminions auth signin`. An opt-in
-      public-access mode can relax this for trusted, local-only use.
+    - **Sign-in gating on the CLI.** The `task`, `knowledge`, `workspace`, and
+      `execution` command groups are wrapped with `require_auth` and refuse to run
+      until you sign in with `miminions auth signin`. An opt-in public-access mode
+      can relax this for trusted, local-only use. (Gating for the `agent`, `chat`,
+      and `prompt` commands is still being stabilized — see the
+      [CLI reference](modules/cli.md).)
     - **Local-first data.** Agents, workspaces, and memory persist under
       `~/.miminions/` on your own machine — nothing is sent to a third party
       beyond your chosen LLM provider.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -112,10 +112,12 @@ from pydantic_ai.models.openai import OpenAIModel
 agent = create_minion("MyAgent", model=OpenAIModel("gpt-4o"))
 ```
 
-!!! warning "Auth happens at call time"
-    A `Minion` builds fine without a key, but `await agent.run(...)` will raise
-    an auth/network error from the provider if the relevant key is missing. Use
-    `provider="test"` to exercise your tools and wiring without any credentials.
+!!! warning "When missing keys surface"
+    With the default `openrouter` provider, a missing `OPENROUTER_API_KEY` fails
+    **fast**: `create_minion(...)` raises `ValueError` at construction. The other
+    real providers build fine without a key and instead raise an auth/network
+    error at `await agent.run(...)` time. Use `provider="test"` to exercise your
+    tools and wiring without any credentials.
 
 Next steps from here: attach [Memory](modules/memory.md), wire in
 [Workspaces](modules/workspaces.md) and [Context](modules/context.md), or expose
@@ -126,7 +128,8 @@ external tools over [MCP](modules/agent.md). See the
 
 Installing the package registers a `miminions` console command (you can also run
 `python -m miminions`). On first run it bootstraps a `default` workspace and a
-default agent under `~/.miminions/`, where all CLI state persists.
+default agent under `~/.miminions/`, where all CLI state persists (set
+`MIMINIONS_HOME` to relocate it).
 
 ```bash
 miminions --help
@@ -138,8 +141,8 @@ Registered command groups: `auth`, `agent`, `task`, `knowledge`, `workspace`,
 ### Chat
 
 Start an interactive async chat session. It runs against the default workspace
-unless you pass `--workspace`, and each reply is printed when the Minion finishes
-responding.
+unless you pass `--workspace`, and each reply streams to the terminal as it is
+generated.
 
 ```bash
 # Interactive session against the default workspace
@@ -150,6 +153,9 @@ miminions chat start --workspace "Demo"
 
 # Resume a prior session — its history is reloaded into LLM context
 miminions chat start --session <session_id>
+
+# Show tool calls and per-turn token usage / latency
+miminions chat start --verbose
 ```
 
 Type `/exit` or `/quit` to end the session.

--- a/docs/modules/agent.md
+++ b/docs/modules/agent.md
@@ -1,6 +1,6 @@
 # Agent
 
-The `miminions.agent` module is the core reasoning engine — a **`Minion`** is an async LLM agent built on [pydantic-ai](https://ai.pydantic.dev/) and, by default, [OpenRouter](https://openrouter.ai/). A `Minion` owns the full agent lifecycle: model selection, a tool registry (plain Python functions, `GenericTool` objects, and MCP-server tools), optional [memory](memory.md), optional [workspace context](context.md) injection, and the async `run()` loop.
+The `miminions.agent` module is the core reasoning engine — a **`Minion`** is an async LLM agent built on [pydantic-ai](https://ai.pydantic.dev/) and, by default, [OpenRouter](https://openrouter.ai/). A `Minion` owns the full agent lifecycle: model selection, a tool registry (plain Python functions, `GenericTool` objects, and MCP-server tools), optional [memory](memory.md), optional [workspace context](context.md) injection, and the async `run()` / `run_stream()` loop.
 
 !!! note "Import from the subpackage"
     Always import from `miminions.agent` — the top-level `import miminions` does not re-export these symbols.
@@ -11,7 +11,9 @@ The `miminions.agent` module is the core reasoning engine — a **`Minion`** is 
 
 ## Features
 
-- **Async execution** — owns its full `async run()` reasoning loop
+- **Async execution** — owns its full `async run()` reasoning loop, with a streaming `run_stream()` variant
+- **Resilience** — per-request timeouts and automatic retries (with exponential backoff) on transient provider errors
+- **Observability hooks** — optional `on_tool_call` / `on_turn_end` callbacks for tool-call and usage/latency reporting
 - **Tool registration** — register plain Python functions or [`GenericTool`](tools.md) objects as LLM-callable tools
 - **MCP integration** — connect to Model Context Protocol servers and load their tools
 - **Memory** — attach any [memory backend](memory.md) and get 7 memory tools auto-registered
@@ -38,7 +40,7 @@ asyncio.run(main())
 ```
 
 !!! warning "Set `OPENROUTER_API_KEY`"
-    The default provider is OpenRouter. `run()` needs a working backend, so export `OPENROUTER_API_KEY` first — otherwise the call fails with an auth/network error. For offline runs (tests, examples), use `provider="test"` (see below).
+    The default provider is OpenRouter, and the key is validated **at construction time**: `create_minion(...)` raises `ValueError` if `OPENROUTER_API_KEY` is not set. Other providers (`openai`, `anthropic`, `gemini`) construct fine without a key and fail at call time instead. For offline runs (tests, examples), use `provider="test"` (see below).
 
 ## Model & Provider Selection
 
@@ -196,7 +198,7 @@ There are three ways to invoke a tool. Pick by how you want errors and results s
 
 | Method | Returns | On error |
 |--------|---------|----------|
-| `await run(prompt)` | the LLM's reply (the model decides which tools to call) | re-raises network/API errors |
+| `await run(prompt)` | the LLM's reply (the model decides which tools to call) | retries transient errors, then re-raises |
 | `execute(name, arguments=None, **kwargs)` | a `ToolExecutionResult` | **never raises** — failure is captured on the result |
 | `execute_tool(name, **kwargs)` | the tool's raw return value | **raises** `ValueError` / `RuntimeError` |
 
@@ -226,6 +228,51 @@ reply1 = await agent.run("My name is Asher.")
 reply2 = await agent.run("What is my name?", message_history=agent._last_messages)
 ```
 
+!!! tip "Bounding long histories"
+    For long sessions, `miminions.session.store.trim_message_history(messages, max_messages=40)` caps the history without breaking request/response pairing — it only cuts at a user-prompt turn boundary, so a trimmed history never starts mid-tool-exchange. The CLI chat loop applies this automatically.
+
+## Streaming Replies
+
+`run_stream()` mirrors `run()` but yields the reply incrementally as text deltas. Tool calls still execute (and fire `on_tool_call`); `on_turn_end` fires when the stream completes, and `_last_messages` is updated only once the stream is fully consumed.
+
+```python
+async for delta in agent.run_stream("Tell me a story."):
+    print(delta, end="", flush=True)
+```
+
+!!! warning "Consume the stream to completion"
+    Breaking out of the loop early abandons the underlying HTTP stream and its deferred cleanup can raise `RuntimeError` at generator close. Also note `run_stream()` does **not** retry transient errors — deltas already yielded cannot be withdrawn, so errors propagate immediately.
+
+## Timeouts, Retries & Hooks
+
+`create_minion` (and `Minion`) accept resilience and observability options:
+
+| Parameter | Default | Meaning |
+|-----------|---------|---------|
+| `request_timeout` | `60.0` | Per-HTTP-request timeout in seconds for model calls (`None` disables it). Bounds each request, **not** the whole turn — a multi-tool turn may take several requests. |
+| `max_retries` | `2` | How many times `run()` retries after a transient model error before re-raising. |
+| `retry_base_delay` | `1.0` | First retry delay in seconds; doubles per attempt (exponential backoff). |
+| `on_tool_call` | `None` | Callback fired as `(tool_name, args)` whenever the model invokes a tool. |
+| `on_turn_end` | `None` | Callback fired as `(usage, latency_seconds)` after each successful turn — `usage` is a pydantic-ai `RunUsage`. |
+
+Transient means HTTP 429/5xx, connection errors, and timeouts (`ModelHTTPError` / `ModelAPIError`); other errors re-raise immediately. Exceptions raised inside either callback are logged and swallowed, so a broken hook never breaks the turn.
+
+```python
+def show_tool(name, args):
+    print(f"[tool] {name} {args}")
+
+def show_usage(usage, latency):
+    print(f"[turn] {usage.input_tokens} in / {usage.output_tokens} out, {latency:.1f}s")
+
+agent = create_minion(
+    "MyAgent",
+    request_timeout=30.0,
+    max_retries=3,
+    on_tool_call=show_tool,
+    on_turn_end=show_usage,
+)
+```
+
 ## API Reference
 
 ### `create_minion`
@@ -237,16 +284,22 @@ create_minion(
     memory: BaseMemory | None = None,
     model: Any | None = None,
     provider: str = "openrouter",
+    request_timeout: float | None = 60.0,
+    max_retries: int = 2,
+    retry_base_delay: float = 1.0,
+    on_tool_call: Callable[[str, dict], None] | None = None,
+    on_turn_end: Callable[[RunUsage, float], None] | None = None,
 ) -> Minion
 ```
 
-Factory that builds a configured `Minion`. When `model` is `None`, `provider` drives model selection (default OpenRouter free model). This is the primary entry point.
+Factory that builds a configured `Minion`. When `model` is `None`, `provider` drives model selection (default OpenRouter free model). See [Timeouts, Retries & Hooks](#timeouts-retries-hooks) for the resilience and callback parameters. This is the primary entry point.
 
 ### `Minion` methods
 
 | Method | Description |
 |--------|-------------|
-| `async run(prompt, message_history=None) -> str` | Send a prompt; the model reasons and calls tools. Returns the reply. |
+| `async run(prompt, message_history=None) -> str` | Send a prompt; the model reasons and calls tools. Retries transient provider errors with backoff. Returns the reply. |
+| `run_stream(prompt, message_history=None) -> AsyncIterator[str]` | Streaming variant of `run()`; yields text deltas. No automatic retry. |
 | `register_tool(name, description, func, schema=None) -> ToolDefinition` | Register a Python function as a tool (schema inferred if omitted). |
 | `add_tool(tool: GenericTool) -> ToolDefinition` | Register a [`GenericTool`](tools.md). |
 | `unregister_tool(name) -> bool` | Remove a tool by name. |

--- a/docs/modules/cli.md
+++ b/docs/modules/cli.md
@@ -11,10 +11,10 @@ python -m miminions --help
 ```
 
 !!! info "State lives under `~/.miminions/`"
-    All persistent CLI state is stored as JSON under your home directory: `config.json`, `auth.json`, `agents.json`, `tasks.json`, `knowledge.json`, `sessions.json`, `interactions.json`, plus a `workspaces/` tree. On the **first** invocation of any command, MiMinions bootstraps a **`default` workspace** and a **`default` agent** so the chat/prompt commands work out of the box.
+    All persistent CLI state is stored as JSON under your home directory: `config.json`, `auth.json`, `agents.json`, `tasks.json`, `knowledge.json`, `sessions.json`, `interactions.json`, plus a `workspaces/` tree. Set the **`MIMINIONS_HOME`** environment variable to relocate the whole directory (handy for tests and alternate deployments). JSON stores are written **atomically**, so an interrupted save can't leave a corrupt file behind. On the **first** invocation of any command, MiMinions bootstraps a **`default` workspace** and a **`default` agent** so the chat/prompt commands work out of the box.
 
-!!! warning "Authentication gating is provisional"
-    A `require_auth` decorator wraps the commands in `agent`, `task`, `knowledge`, `workspace`, and `execution`, but auth is **not actively enforced today** — treat the gating as **planned**, the same as the `workflow` group below. The hooks exist in the code so the behavior can be turned on later, but don't rely on commands being blocked when signed out. The `chat` and `prompt` commands are not wrapped at all.
+!!! warning "Authentication gating is uneven"
+    A `require_auth` decorator gates the commands in `task`, `knowledge`, `workspace`, and `execution`: when you are signed out (and public access is off) they print a sign-in hint and refuse to run. The `agent` group, however, currently uses a **no-op stand-in** while auth is stabilized, and the `chat` and `prompt` commands are not wrapped at all — don't rely on those being blocked when signed out.
 
 ## Command groups at a glance
 
@@ -50,14 +50,18 @@ miminions chat start --workspace my-project
 
 # Resume a prior conversation by session id
 miminions chat start --session 20260621T101500000000Z_a1b2c3d4
+
+# Show tool calls, token usage and latency per turn
+miminions chat start --verbose
 ```
 
 | Option | Description |
 | --- | --- |
 | `--workspace <id\|name>` | Workspace to run in. Defaults to the configured default workspace. |
 | `--session <id>` | Resume an existing session id (loads prior history into the LLM context). |
+| `--verbose` | Print each tool call and per-turn token usage / latency to stderr. |
 
-Inside the loop, type a message and press Enter to get a reply. Type **`/exit`** or **`/quit`** (or send EOF / `Ctrl-C`) to end the session. Every turn is appended to the session transcript, and on exit a background memory distillation pass runs.
+Inside the loop, type a message and press Enter — the reply **streams** to the terminal as it is generated. Type **`/exit`** or **`/quit`** (or send EOF / `Ctrl-C`) to end the session. Every turn is appended to the session transcript, and on exit a background memory distillation pass runs.
 
 ```text
 Workspace : my-project
@@ -72,7 +76,10 @@ Session ended.
 ```
 
 !!! tip "Needs an LLM backend"
-    Chat (and `prompt`) call the live model. With the default OpenRouter provider you must export `OPENROUTER_API_KEY`; otherwise the model call fails and the reply is returned as an `[error] ...` line. See [Agent](agent.md#model-provider-selection) for switching providers.
+    Chat (and `prompt`) call the live model. With the default OpenRouter provider you must export `OPENROUTER_API_KEY` — without it, agent construction fails with a clear `ValueError`. Errors during a turn are shown as an `[error] ...` line; if a reply was partially streamed before the error, the partial text is kept in the transcript alongside the error marker. See [Agent](agent.md#model-provider-selection) for switching providers.
+
+??? note "Bounded LLM context (how it works)"
+    Before each turn the in-memory history passed to the LLM is capped at the most recent **40 messages** via `trim_message_history`, cutting only at a user-prompt turn boundary so tool call/return pairs are never split. The JSONL transcript on disk always stays complete — only the model's context window is bounded.
 
 ??? note "Session resumption (how it works)"
     Passing `--session <id>` loads the append-only `.jsonl` transcript from `JsonlSessionStore` and converts it back into native pydantic-ai messages via `load_as_pydantic_messages()`, giving the LLM full conversational context from prior runs. New sessions get an id of the form `YYYYMMDDTHHMMSSffffffZ_<8-char-uuid>`. Transcripts live under `<workspace_root>/sessions/`.
@@ -153,7 +160,7 @@ miminions agent remove researcher
 | Command | Options | Description |
 | --- | --- | --- |
 | `list` | — | List all agent records with status and description. |
-| `add` | `--name`, `--description`, `--type` | Create a record (id is the slugified name). All three are prompted if omitted. |
+| `add` | `--name`, `--description`, `--type` | Create a record (id is the slugified name; a `_2`, `_3`, … suffix is appended if the id is already taken). All three are prompted if omitted. |
 | `update <id>` | `--name`, `--description`, `--type` | Update fields on an existing record. |
 | `remove <id>` | — | Delete a record (asks for confirmation). |
 | `set-goal <id>` | `--goal` | Store a goal used by `run`. |

--- a/docs/modules/context.md
+++ b/docs/modules/context.md
@@ -155,10 +155,11 @@ builder = ContextBuilder(global_top_k=5, global_db_path="/path/to/global.db")
     *and* the lookup returns at least one insight. With `global_top_k=0`, both the
     section and the SQLite lookup are skipped. Global insights are stored by the
     [`MemoryDistiller`](memory.md); reading them requires the `[sqlite]` extra
-    (`pip install miminions[sqlite]`). Any error during the lookup is swallowed —
-    the section is omitted rather than failing the build.
+    (`pip install miminions[sqlite]`). Any error during the lookup is logged as a
+    warning and swallowed — the section is omitted rather than failing the build.
 
-The default database path is `~/.miminions/global_memory.db`.
+The default database path is `~/.miminions/global_memory.db` (resolved via
+`miminions.core.paths`, so it honors the `MIMINIONS_HOME` environment variable).
 
 ## API Reference
 

--- a/docs/modules/memory.md
+++ b/docs/modules/memory.md
@@ -133,6 +133,14 @@ memory.delete(entry_id)
 memory.close()
 ```
 
+`SQLiteMemory` is also a **context manager** — the connection closes automatically on exit:
+
+```python
+with SQLiteMemory("memory.db") as memory:
+    memory.create("Python is a programming language")
+    results = memory.read("languages for coding", top_k=5)
+```
+
 The constructor `SQLiteMemory(db_path=None, model_name="all-MiniLM-L6-v2", dim=384)` resolves storage by `db_path`:
 
 === "Persistent (path)"
@@ -204,19 +212,22 @@ memory.close()
 | `list_all() -> list[dict]` | Return every entry (no limit). |
 | `clear() -> None` | Delete all entries. |
 | `close()` | Close the underlying SQLite connection. |
+| `__enter__` / `__exit__` | Context-manager support; `with SQLiteMemory(...) as mem:` closes the connection on exit. |
 
 !!! note "Extension support"
     `SQLiteMemory` needs SQLite extension loading. The `sqlite` extra installs `pysqlite3` for this; if your Python's `sqlite3` lacks extension support, the constructor raises `RuntimeError("SQLite extension loading not supported. Install pysqlite3: pip install pysqlite3")`.
 
 ### Global memory path
 
-The canonical cross-workspace database lives at `~/.miminions/global_memory.db`. Resolve it programmatically with:
+The canonical cross-workspace database lives at `~/.miminions/global_memory.db` (or under `$MIMINIONS_HOME` if that environment variable is set). Resolve it programmatically with:
 
 ```python
-from miminions.memory.sqlite import get_global_memory_db_path
+from miminions.core.paths import get_global_memory_db_path
 
-path = get_global_memory_db_path()   # creates ~/.miminions if needed
+path = get_global_memory_db_path()   # creates the config dir if needed
 ```
+
+The function's canonical home is `miminions.core.paths`; it is still re-exported from `miminions.memory.sqlite` for backwards compatibility.
 
 ## Attaching memory to an agent
 

--- a/docs/modules/workspaces.md
+++ b/docs/modules/workspaces.md
@@ -65,6 +65,22 @@ print(same_ws.get_network_summary())
     `resolve_workspace(workspaces, ref)`, where `ref` is an exact id, an id prefix,
     or the exact name.
 
+### Persistence & schema versioning
+
+`save_workspaces()` writes `workspaces.json` **atomically** (a temp file swapped
+into place), so an interrupted save can't corrupt the store. Each persisted
+record is stamped with a `schema_version` field (currently `1`):
+
+- Records **without** a version predate versioning and are treated as v1 — they
+  get stamped on the next save.
+- Records with a **newer** version than the running code supports are loaded
+  best-effort with a logged warning.
+- Future breaking changes to the record shape will dispatch on this version in
+  a migration step at load time.
+
+If `workspaces.json` is missing or unreadable, `load_workspaces()` logs a
+warning and returns `{}` rather than raising.
+
 ## The Graph Model
 
 A workspace aggregates three things: a dict of `Node`s, a dict of `Rule`s (plus a
@@ -287,7 +303,8 @@ default agent in `agents.json`, and records both ids in `config.json`.
 ## CLI
 
 The same operations are available from the `miminions workspace` command group, which
-stores everything under `~/.miminions/`.
+stores everything under `~/.miminions/` (override the location with the
+`MIMINIONS_HOME` environment variable).
 
 ```bash
 # Create a workspace and scaffold its folder
@@ -323,8 +340,8 @@ See the [CLI reference](cli.md) for the full command set.
 
 | Method | Description |
 |--------|-------------|
-| `load_workspaces() -> dict[str, Workspace]` | Read `workspaces.json`; returns `{}` if missing or unreadable |
-| `save_workspaces(workspaces)` | Write the dict back to `workspaces.json` |
+| `load_workspaces() -> dict[str, Workspace]` | Read `workspaces.json` (migrating each record to the current schema version); returns `{}` if missing or unreadable |
+| `save_workspaces(workspaces)` | Atomically write the dict back to `workspaces.json` |
 | `create_workspace(name, description="")` | Build a new in-memory `Workspace` (not persisted) |
 | `create_sample_workspace()` | Build a demo workspace with example nodes, rules, and state |
 

--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -4,7 +4,7 @@ import asyncio
 import inspect
 import logging
 import time
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 from pathlib import Path
 
 from pydantic_ai import Agent, Tool
@@ -552,6 +552,40 @@ class Minion:
             except Exception:
                 logger.exception("on_turn_end callback failed")
         return result.output if hasattr(result, "output") else str(result.data)
+
+    async def run_stream(
+        self, prompt: str, message_history: Optional[List[Any]] = None
+    ) -> AsyncIterator[str]:
+        """Stream the LLM reply as text deltas.
+
+        Mirrors :meth:`run` but yields the reply incrementally. Tool calls
+        still execute (and fire ``on_tool_call``); ``on_turn_end`` fires once
+        the stream completes. ``_last_messages`` is updated only when the
+        stream is fully consumed.
+
+        Unlike :meth:`run` there is no automatic retry: deltas already
+        yielded cannot be withdrawn, so errors propagate immediately.
+        ``request_timeout`` still bounds each HTTP request.
+
+        The stream must be consumed to completion — breaking out of the
+        loop early abandons the underlying HTTP stream, and its deferred
+        cleanup can raise ``RuntimeError`` at generator close.
+        """
+        self._rebuild_pydantic_ai_agent()
+        start = time.monotonic()
+        async with self._pydantic_ai_agent.run_stream(
+            prompt,
+            message_history=message_history or None,
+            event_stream_handler=self._make_event_stream_handler(),
+        ) as result:
+            async for delta in result.stream_text(delta=True):
+                yield delta
+            self._last_messages = result.all_messages()
+            if self._on_turn_end is not None:
+                try:
+                    self._on_turn_end(result.usage, time.monotonic() - start)
+                except Exception:
+                    logger.exception("on_turn_end callback failed")
 
     def set_context(self, workspace: Any, root_path: str | Path) -> None:
         """Attach workspace context so ContextBuilder feeds the system prompt.

--- a/src/miminions/agent/agent.py
+++ b/src/miminions/agent/agent.py
@@ -2,11 +2,16 @@
 
 import asyncio
 import inspect
+import logging
 import time
 from typing import Any, Callable, Dict, List, Optional
 from pathlib import Path
 
 from pydantic_ai import Agent, Tool
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+from pydantic_ai.messages import FunctionToolCallEvent
+from pydantic_ai.settings import ModelSettings
+from pydantic_ai.usage import RunUsage
 from mcp import StdioServerParameters
 
 from miminions.agent.provider import ModelFactory
@@ -26,6 +31,15 @@ from miminions.tools.schemas import (
     ToolExecutionResult, ToolParameter, ToolSchema,
 )
 from miminions.memory.types import MemoryEntry, MemoryQueryResult
+
+logger = logging.getLogger(__name__)
+
+
+def _is_retryable_error(exc: BaseException) -> bool:
+    """True for transient provider failures worth retrying."""
+    if isinstance(exc, ModelHTTPError):  # subclass of ModelAPIError — check first
+        return exc.status_code == 429 or exc.status_code >= 500
+    return isinstance(exc, ModelAPIError)  # connection errors / timeouts
 
 
 def _python_type_to_param_type(py_type: type) -> ParameterType:
@@ -92,8 +106,18 @@ class Minion:
         overlap: int = 150,
         model: Optional[Any] = None,
         provider: str = "openrouter",
+        request_timeout: Optional[float] = 60.0,
+        max_retries: int = 2,
+        retry_base_delay: float = 1.0,
+        on_tool_call: Optional[Callable[[str, Dict[str, Any]], None]] = None,
+        on_turn_end: Optional[Callable[[RunUsage, float], None]] = None,
     ):
         self.config = AgentConfig(name=name, description=description, chunk_size=chunk_size, overlap=overlap)
+        self._request_timeout = request_timeout
+        self._max_retries = max_retries
+        self._retry_base_delay = retry_base_delay
+        self._on_tool_call = on_tool_call
+        self._on_turn_end = on_turn_end
         self._tools: Dict[str, RegisteredTool] = {}
         self._memory = memory
         self._mcp_adapter = MCPToolAdapter()
@@ -152,10 +176,17 @@ class Minion:
         registered as a ``@agent.system_prompt`` callback so the LLM
         receives the full workspace context on every call.
         """
+        # request_timeout bounds each HTTP request to the provider, not the
+        # whole turn — a multi-tool turn may take several requests.
         agent = Agent(
             model=self._model,
             tools=self._pydantic_ai_tools,
             instructions=self.config.description or f"Agent: {self.config.name}",
+            model_settings=(
+                ModelSettings(timeout=self._request_timeout)
+                if self._request_timeout is not None
+                else None
+            ),
         )
 
         # Wire ContextBuilder into the system prompt when workspace context
@@ -444,6 +475,26 @@ class Minion:
         if rebuild:
             self._rebuild_pydantic_ai_agent()
 
+    def _make_event_stream_handler(self) -> Optional[Callable[..., Any]]:
+        """Build a pydantic_ai event-stream handler wiring ``on_tool_call``.
+
+        Returns ``None`` when no callback is registered so the run path is
+        byte-for-byte identical to the un-hooked behavior.
+        """
+        callback = self._on_tool_call
+        if callback is None:
+            return None
+
+        async def _handler(_ctx: Any, event_stream: Any) -> None:
+            async for event in event_stream:
+                if isinstance(event, FunctionToolCallEvent):
+                    try:
+                        callback(event.part.tool_name, event.part.args_as_dict())
+                    except Exception:
+                        logger.exception("on_tool_call callback failed")
+
+        return _handler
+
     async def run(self, prompt: str, message_history: Optional[List[Any]] = None) -> str:
         """Send a prompt to the LLM and return the reply as a plain string.
 
@@ -453,6 +504,11 @@ class Minion:
         The full message list is stored on ``_last_messages`` after each call
         so the caller can pass it back in on the next turn for multi-turn
         conversation memory within a session.
+
+        Transient provider failures (HTTP 429/5xx, connection errors and
+        timeouts) are retried up to ``max_retries`` times with exponential
+        backoff before the error is re-raised. ``request_timeout`` bounds each
+        HTTP request, not the whole turn.
 
         Args:
             prompt: The user message to send.
@@ -464,15 +520,37 @@ class Minion:
             The LLM's reply as a plain string.
 
         Raises:
-            Exception: Re-raises any network / API error so the caller can
-                       decide how to surface it.
+            Exception: Re-raises any non-transient (or retry-exhausted)
+                       network / API error so the caller can decide how to
+                       surface it.
         """
         self._rebuild_pydantic_ai_agent()
-        result = await self._pydantic_ai_agent.run(
-            prompt,
-            message_history=message_history or None,
-        )
+        start = time.monotonic()
+        attempt = 0
+        while True:
+            try:
+                result = await self._pydantic_ai_agent.run(
+                    prompt,
+                    message_history=message_history or None,
+                    event_stream_handler=self._make_event_stream_handler(),
+                )
+                break
+            except Exception as exc:
+                if attempt >= self._max_retries or not _is_retryable_error(exc):
+                    raise
+                delay = self._retry_base_delay * (2 ** attempt)
+                logger.warning(
+                    "Transient model error (%s); retrying in %.1fs (attempt %d/%d)",
+                    exc, delay, attempt + 1, self._max_retries,
+                )
+                await asyncio.sleep(delay)
+                attempt += 1
         self._last_messages = result.all_messages()
+        if self._on_turn_end is not None:
+            try:
+                self._on_turn_end(result.usage, time.monotonic() - start)
+            except Exception:
+                logger.exception("on_turn_end callback failed")
         return result.output if hasattr(result, "output") else str(result.data)
 
     def set_context(self, workspace: Any, root_path: str | Path) -> None:
@@ -509,10 +587,15 @@ def create_minion(
     memory: Optional[BaseMemory] = None,
     model: Optional[Any] = None,
     provider: str = "openrouter",
+    request_timeout: Optional[float] = 60.0,
+    max_retries: int = 2,
+    retry_base_delay: float = 1.0,
+    on_tool_call: Optional[Callable[[str, Dict[str, Any]], None]] = None,
+    on_turn_end: Optional[Callable[[RunUsage, float], None]] = None,
 ) -> Minion:
     """
     Create a new Minion instance.
-    
+
     Args:
         name: Agent name
         description: Agent description
@@ -520,8 +603,28 @@ def create_minion(
         model: Optional pydantic_ai model. Defaults to None.
                Pass a real model like 'openai:gpt-4' for LLM support.
         provider: The string name of the provider. Defaults to "openrouter".
-    
+        request_timeout: Per-HTTP-request timeout in seconds for model calls
+                         (None disables it).
+        max_retries: Retries after a transient model error (429/5xx,
+                     connection failures) before re-raising.
+        retry_base_delay: First retry delay in seconds; doubles per attempt.
+        on_tool_call: Optional callback fired as ``(tool_name, args)`` when
+                      the model invokes a tool.
+        on_turn_end: Optional callback fired as ``(usage, latency_seconds)``
+                     after each successful turn.
+
     Returns:
         Minion instance ready for tool registration and execution
     """
-    return Minion(name=name, description=description, memory=memory, model=model, provider=provider)
+    return Minion(
+        name=name,
+        description=description,
+        memory=memory,
+        model=model,
+        provider=provider,
+        request_timeout=request_timeout,
+        max_retries=max_retries,
+        retry_base_delay=retry_base_delay,
+        on_tool_call=on_tool_call,
+        on_turn_end=on_turn_end,
+    )

--- a/src/miminions/cli/chat.py
+++ b/src/miminions/cli/chat.py
@@ -12,7 +12,7 @@ from pydantic_ai.usage import RunUsage
 
 from miminions.agent import create_minion
 from miminions.memory import MemoryDistiller
-from miminions.session.store import JsonlSessionStore
+from miminions.session.store import JsonlSessionStore, trim_message_history
 from miminions.core.workspace import WorkspaceManager, ensure_workspace
 from miminions.cli.auth import get_config, get_config_dir
 
@@ -123,7 +123,7 @@ async def _chat_loop(workspace_ref: str, session_id: str | None, verbose: bool =
     2. Create the Minion once — it lives for the entire session.
     3. Wire workspace context via set_context() so the LLM sees it.
     4. If resuming a session, load prior JSONL as pydantic_ai messages.
-    5. Loop: input → minion.run() → print reply.
+    5. Loop: input → minion.run_stream() → print deltas as they arrive.
     6. On exit, run session distillation in the finally block.
     """
     manager = WorkspaceManager(get_config_dir())
@@ -181,15 +181,29 @@ async def _chat_loop(workspace_ref: str, session_id: str | None, verbose: bool =
                 meta={"source": "cli-chat"},
             )
 
+            # Bound the LLM context for long sessions; the JSONL transcript
+            # on disk stays complete.
+            message_history = trim_message_history(message_history)
+
+            reply_parts: list[str] = []
             try:
-                reply = await minion.run(
+                click.echo("")
+                async for delta in minion.run_stream(
                     user_text,
                     message_history=message_history,
-                )
+                ):
+                    click.echo(delta, nl=False)
+                    reply_parts.append(delta)
+                click.echo("\n")
+                reply = "".join(reply_parts)
                 # Update history so the LLM remembers prior turns.
                 message_history = minion._last_messages
             except Exception as exc:
-                reply = f"[error] {type(exc).__name__}: {exc}"
+                error_text = f"[error] {type(exc).__name__}: {exc}"
+                click.echo(f"\n{error_text}\n")
+                # Keep the transcript faithful to what was shown on screen:
+                # persist any partial reply alongside the error marker.
+                reply = "\n".join(filter(None, ["".join(reply_parts), error_text]))
 
             store.append(
                 session_id,
@@ -197,8 +211,6 @@ async def _chat_loop(workspace_ref: str, session_id: str | None, verbose: bool =
                 reply,
                 meta={"source": "cli-chat"},
             )
-
-            click.echo(f"\n{reply}\n")
     finally:
         try:
             _run_session_distillation(

--- a/src/miminions/cli/chat.py
+++ b/src/miminions/cli/chat.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from typing import Any
 
 import click
+from pydantic_ai.usage import RunUsage
 
 from miminions.agent import create_minion
 from miminions.memory import MemoryDistiller
@@ -75,15 +77,23 @@ def chat_cli():
     default=None,
     help="Resume an existing session id (loads prior history for LLM context).",
 )
-def chat_command(workspace_ref: str | None, session_id: str | None) -> None:
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Show tool calls, token usage and latency per turn.",
+)
+def chat_command(workspace_ref: str | None, session_id: str | None, verbose: bool) -> None:
     """Start an interactive async chat session for a workspace."""
+    if verbose:
+        logging.basicConfig(level=logging.INFO)
     if not workspace_ref:
         workspace_ref = get_config().get("default_workspace")
         if not workspace_ref:
             raise click.ClickException(
                 "No --workspace given and no default workspace configured."
             )
-    asyncio.run(_chat_loop(workspace_ref, session_id))
+    asyncio.run(_chat_loop(workspace_ref, session_id, verbose))
 
 
 # ---------------------------------------------------------------------------
@@ -91,7 +101,22 @@ def chat_command(workspace_ref: str | None, session_id: str | None) -> None:
 # ---------------------------------------------------------------------------
 
 
-async def _chat_loop(workspace_ref: str, session_id: str | None) -> None:
+def _print_tool_call(name: str, args: dict[str, Any]) -> None:
+    """Verbose-mode hook: show each tool invocation on stderr."""
+    click.secho(f"  [tool] {name} {args}", dim=True, err=True)
+
+
+def _print_turn_end(usage: RunUsage, latency: float) -> None:
+    """Verbose-mode hook: show token usage and latency on stderr."""
+    click.secho(
+        f"  [turn] {usage.input_tokens or 0} in / {usage.output_tokens or 0} out tokens, "
+        f"{usage.tool_calls} tool call(s), {latency:.1f}s",
+        dim=True,
+        err=True,
+    )
+
+
+async def _chat_loop(workspace_ref: str, session_id: str | None, verbose: bool = False) -> None:
     """Main async chat loop.
 
     1. Resolve the workspace and build the root path.
@@ -117,6 +142,8 @@ async def _chat_loop(workspace_ref: str, session_id: str | None) -> None:
     minion = create_minion(
         name="MiMinions",
         description=f"MiMinions agent for workspace '{workspace_name}'.",  # TODO: make customizable per workspace
+        on_tool_call=_print_tool_call if verbose else None,
+        on_turn_end=_print_turn_end if verbose else None,
     )
     minion.set_context(workspace, root)
 

--- a/src/miminions/context/context_builder.py
+++ b/src/miminions/context/context_builder.py
@@ -140,12 +140,9 @@ def _fetch_global_insights(top_k: int = 5, db_path: str | None = None) -> list[s
     try:
         from miminions.memory.sqlite import SQLiteMemory
 
-        mem = SQLiteMemory(db_path=path)
-        try:
+        with SQLiteMemory(db_path=path) as mem:
             rows = mem.date_time_search(top_k=top_k)
             return [r["text"] for r in rows if r.get("text")]
-        finally:
-            mem.close()
     except Exception:
         logger.warning(
             "Could not fetch global insights from %s; continuing without them.",

--- a/src/miminions/core/workspace.py
+++ b/src/miminions/core/workspace.py
@@ -15,10 +15,16 @@ from dataclasses import dataclass, asdict, field
 from enum import Enum
 
 from miminions.core.paths import get_workspaces_root
+from miminions.core.persistence import save_json
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_WORKSPACES_ROOT = get_workspaces_root()
+
+# Version of the persisted workspace record format. Bump on any breaking
+# change to to_dict()'s shape and add a migration step in
+# _migrate_workspace_record().
+WORKSPACE_SCHEMA_VERSION = 1
 
 
 class NodeType(Enum):
@@ -278,6 +284,7 @@ class Workspace:
     def to_dict(self) -> Dict[str, Any]:
         """Convert workspace to dictionary."""
         return {
+            'schema_version': WORKSPACE_SCHEMA_VERSION,
             'id': self.id,
             'name': self.name,
             'description': self.description,
@@ -322,6 +329,31 @@ class Workspace:
         return workspace
 
 
+def _migrate_workspace_record(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize a persisted workspace record to WORKSPACE_SCHEMA_VERSION.
+
+    Records without a version predate versioning and are treated as v1
+    (they get stamped on the next save). Future format changes dispatch on
+    the record's version here, e.g. ``if version == 1: data = _v1_to_v2(data)``.
+    """
+    try:
+        version = int(data.get('schema_version', 1))
+    except (TypeError, ValueError):
+        logger.warning(
+            "Workspace %s has invalid schema_version %r; treating as %d.",
+            data.get('id', '<unknown>'), data.get('schema_version'),
+            WORKSPACE_SCHEMA_VERSION,
+        )
+        version = WORKSPACE_SCHEMA_VERSION
+    if version > WORKSPACE_SCHEMA_VERSION:
+        logger.warning(
+            "Workspace %s has schema_version %d, newer than supported %d; "
+            "loading best-effort.",
+            data.get('id', '<unknown>'), version, WORKSPACE_SCHEMA_VERSION,
+        )
+    return data
+
+
 class WorkspaceManager:
     """Manager for workspace operations and persistence."""
     
@@ -341,8 +373,10 @@ class WorkspaceManager:
             
             workspaces = {}
             for workspace_id, workspace_data in data.items():
-                workspaces[workspace_id] = Workspace.from_dict(workspace_data)
-            
+                workspaces[workspace_id] = Workspace.from_dict(
+                    _migrate_workspace_record(workspace_data)
+                )
+
             return workspaces
         except Exception:
             logger.warning(
@@ -356,14 +390,11 @@ class WorkspaceManager:
     
     def save_workspaces(self, workspaces: Dict[str, Workspace]) -> None:
         """Save workspaces to storage."""
-        self.config_dir.mkdir(exist_ok=True)
-        
         data = {}
         for workspace_id, workspace in workspaces.items():
             data[workspace_id] = workspace.to_dict()
-        
-        with open(self.workspaces_file, 'w') as f:
-            json.dump(data, f, indent=2)
+
+        save_json(self.workspaces_file, data)
     
     def create_workspace(self, name: str, description: str = "") -> Workspace:
         """Create a new workspace."""

--- a/src/miminions/memory/distiller.py
+++ b/src/miminions/memory/distiller.py
@@ -166,8 +166,7 @@ class MemoryDistiller:
             try:
                 from .sqlite import SQLiteMemory
 
-                sqlite_memory = SQLiteMemory(db_path=self.global_db_path)
-                try:
+                with SQLiteMemory(db_path=self.global_db_path) as sqlite_memory:
                     for insight_text in global_insights:
                         metadata = self._build_tier3_metadata(
                             workspace=workspace,
@@ -181,8 +180,6 @@ class MemoryDistiller:
                                 "metadata": metadata,
                             }
                         )
-                finally:
-                    sqlite_memory.close()
             except Exception as exc:
                 logger.warning(
                     "Tier-3 global memory write failed for session %s: %s",

--- a/src/miminions/memory/sqlite.py
+++ b/src/miminions/memory/sqlite.py
@@ -303,7 +303,13 @@ class SQLiteMemory(BaseMemory):
     
     def close(self):
         self.conn.close()
-    
+
+    def __enter__(self) -> "SQLiteMemory":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
     def __del__(self):
         if hasattr(self, 'conn'):
             self.conn.close()

--- a/src/miminions/session/store.py
+++ b/src/miminions/session/store.py
@@ -10,6 +10,35 @@ from miminions.workspace_fs.layout import WorkspaceLayout
 
 JsonDict = Dict[str, Any]
 
+DEFAULT_MAX_HISTORY_MESSAGES = 40
+
+
+def trim_message_history(
+    messages: list, max_messages: int = DEFAULT_MAX_HISTORY_MESSAGES
+) -> list:
+    """Cap pydantic_ai message history without breaking request/response pairing.
+
+    Cuts only at a turn boundary — a ``ModelRequest`` containing a
+    ``UserPromptPart`` — so the result never starts mid-tool-exchange (a
+    ``ModelRequest`` holding only a ``ToolReturnPart`` whose matching tool
+    call was dropped would be rejected by providers). If no clean boundary
+    exists within the tail, the history is returned unchanged rather than
+    corrupted.
+    """
+    if max_messages <= 0 or len(messages) <= max_messages:
+        return messages
+
+    from pydantic_ai.messages import ModelRequest, UserPromptPart
+
+    for i in range(len(messages) - max_messages, len(messages)):
+        message = messages[i]
+        if isinstance(message, ModelRequest) and any(
+            isinstance(part, UserPromptPart) for part in message.parts
+        ):
+            return messages[i:]
+    return messages
+
+
 def create_session_id() -> str:
     """Create a readable unique session id.
 

--- a/tests/integration/test_cli_chat.py
+++ b/tests/integration/test_cli_chat.py
@@ -79,6 +79,67 @@ def test_chat_cli_creates_session_and_logs_messages(tmp_path: Path, monkeypatch)
     assert '"content": "assistant reply"' in contents, f"Expected 'content: assistant reply' in contents, but got: {contents}"
 
 
+def test_chat_cli_verbose_wires_hooks_into_minion(tmp_path: Path, monkeypatch):
+    init_workspace(tmp_path)
+
+    workspace = SimpleNamespace(
+        id="ws1",
+        name="Test WS",
+        root_path=str(tmp_path),
+        nodes=[],
+        rules=[],
+        state={},
+    )
+    manager = MagicMock()
+    manager.load_workspaces.return_value = {workspace.id: workspace}
+
+    captured_kwargs = {}
+
+    class MockMinion:
+        def __init__(self, *args, **kwargs):
+            self._last_messages = []
+            self._model = None
+        def set_context(self, *args, **kwargs):
+            pass
+        async def run(self, *args, **kwargs):
+            return "assistant reply"
+
+    def _capturing_create_minion(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return MockMinion()
+
+    monkeypatch.setattr(
+        "miminions.cli.chat.WorkspaceManager",
+        lambda config_dir: manager,
+    )
+    monkeypatch.setattr(
+        "miminions.cli.chat.create_minion",
+        _capturing_create_minion,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        chat_command,
+        ["--workspace", "ws1", "--verbose"],
+        input="/quit\n",
+    )
+
+    assert result.exit_code == 0
+    assert callable(captured_kwargs["on_tool_call"])
+    assert callable(captured_kwargs["on_turn_end"])
+
+    captured_kwargs.clear()
+    result = runner.invoke(
+        chat_command,
+        ["--workspace", "ws1"],
+        input="/quit\n",
+    )
+
+    assert result.exit_code == 0
+    assert captured_kwargs["on_tool_call"] is None
+    assert captured_kwargs["on_turn_end"] is None
+
+
 def test_chat_cli_runs_distillation_once_on_exit(tmp_path: Path, monkeypatch):
     init_workspace(tmp_path)
 

--- a/tests/integration/test_cli_chat.py
+++ b/tests/integration/test_cli_chat.py
@@ -45,8 +45,8 @@ def test_chat_cli_creates_session_and_logs_messages(tmp_path: Path, monkeypatch)
             self._model = None
         def set_context(self, *args, **kwargs):
             pass
-        async def run(self, *args, **kwargs):
-            return "assistant reply"
+        async def run_stream(self, *args, **kwargs):
+            yield "assistant reply"
 
     monkeypatch.setattr(
         "miminions.cli.chat.WorkspaceManager",
@@ -79,6 +79,101 @@ def test_chat_cli_creates_session_and_logs_messages(tmp_path: Path, monkeypatch)
     assert '"content": "assistant reply"' in contents, f"Expected 'content: assistant reply' in contents, but got: {contents}"
 
 
+def test_chat_cli_streams_deltas_incrementally(tmp_path: Path, monkeypatch):
+    init_workspace(tmp_path)
+
+    workspace = SimpleNamespace(
+        id="ws1",
+        name="Test WS",
+        root_path=str(tmp_path),
+        nodes=[],
+        rules=[],
+        state={},
+    )
+    manager = MagicMock()
+    manager.load_workspaces.return_value = {workspace.id: workspace}
+
+    class MockMinion:
+        def __init__(self, *args, **kwargs):
+            self._last_messages = []
+            self._model = None
+        def set_context(self, *args, **kwargs):
+            pass
+        async def run_stream(self, *args, **kwargs):
+            yield "foo"
+            yield "bar"
+
+    monkeypatch.setattr(
+        "miminions.cli.chat.WorkspaceManager",
+        lambda config_dir: manager,
+    )
+    monkeypatch.setattr(
+        "miminions.cli.chat.create_minion",
+        lambda *args, **kwargs: MockMinion()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        chat_command,
+        ["--workspace", "ws1"],
+        input="hello\n/quit\n",
+    )
+
+    assert result.exit_code == 0
+    assert "foobar" in result.output
+
+    contents = next((tmp_path / "sessions").glob("*.jsonl")).read_text(encoding="utf-8")
+    assert '"content": "foobar"' in contents
+
+
+def test_chat_cli_persists_partial_reply_on_mid_stream_error(tmp_path: Path, monkeypatch):
+    init_workspace(tmp_path)
+
+    workspace = SimpleNamespace(
+        id="ws1",
+        name="Test WS",
+        root_path=str(tmp_path),
+        nodes=[],
+        rules=[],
+        state={},
+    )
+    manager = MagicMock()
+    manager.load_workspaces.return_value = {workspace.id: workspace}
+
+    class MockMinion:
+        def __init__(self, *args, **kwargs):
+            self._last_messages = []
+            self._model = None
+        def set_context(self, *args, **kwargs):
+            pass
+        async def run_stream(self, *args, **kwargs):
+            yield "partial text"
+            raise RuntimeError("stream died")
+
+    monkeypatch.setattr(
+        "miminions.cli.chat.WorkspaceManager",
+        lambda config_dir: manager,
+    )
+    monkeypatch.setattr(
+        "miminions.cli.chat.create_minion",
+        lambda *args, **kwargs: MockMinion()
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        chat_command,
+        ["--workspace", "ws1"],
+        input="hello\n/quit\n",
+    )
+
+    assert result.exit_code == 0
+    assert "[error] RuntimeError: stream died" in result.output
+
+    contents = next((tmp_path / "sessions").glob("*.jsonl")).read_text(encoding="utf-8")
+    assert "partial text" in contents
+    assert "[error] RuntimeError: stream died" in contents
+
+
 def test_chat_cli_verbose_wires_hooks_into_minion(tmp_path: Path, monkeypatch):
     init_workspace(tmp_path)
 
@@ -101,8 +196,8 @@ def test_chat_cli_verbose_wires_hooks_into_minion(tmp_path: Path, monkeypatch):
             self._model = None
         def set_context(self, *args, **kwargs):
             pass
-        async def run(self, *args, **kwargs):
-            return "assistant reply"
+        async def run_stream(self, *args, **kwargs):
+            yield "assistant reply"
 
     def _capturing_create_minion(*args, **kwargs):
         captured_kwargs.update(kwargs)
@@ -162,8 +257,8 @@ def test_chat_cli_runs_distillation_once_on_exit(tmp_path: Path, monkeypatch):
             self._model = None
         def set_context(self, *args, **kwargs):
             pass
-        async def run(self, *args, **kwargs):
-            return "assistant reply"
+        async def run_stream(self, *args, **kwargs):
+            yield "assistant reply"
 
     monkeypatch.setattr(
         "miminions.cli.chat.WorkspaceManager",
@@ -212,8 +307,8 @@ def test_chat_cli_distillation_error_is_warning_only(tmp_path: Path, monkeypatch
             self._model = None
         def set_context(self, *args, **kwargs):
             pass
-        async def run(self, *args, **kwargs):
-            return "assistant reply"
+        async def run_stream(self, *args, **kwargs):
+            yield "assistant reply"
 
     monkeypatch.setattr(
         "miminions.cli.chat.WorkspaceManager",

--- a/tests/integration/test_distiller.py
+++ b/tests/integration/test_distiller.py
@@ -23,6 +23,12 @@ class _FakeSQLiteMemory:
     def close(self) -> None:
         return None
 
+    def __enter__(self) -> "_FakeSQLiteMemory":
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self.close()
+
 
 def test_distillation_result_defaults():
     result = DistillationResult()

--- a/tests/integration/test_session_store.py
+++ b/tests/integration/test_session_store.py
@@ -1,7 +1,36 @@
 from pathlib import Path
 
-from miminions.session.store import JsonlSessionStore, create_session_id
+from pydantic_ai.messages import (
+    ModelRequest,
+    ModelResponse,
+    TextPart,
+    ToolCallPart,
+    ToolReturnPart,
+    UserPromptPart,
+)
+
+from miminions.session.store import (
+    JsonlSessionStore,
+    create_session_id,
+    trim_message_history,
+)
 from miminions.workspace_fs.bootstrap import init_workspace
+
+
+def _user(content: str) -> ModelRequest:
+    return ModelRequest(parts=[UserPromptPart(content=content)])
+
+
+def _assistant(content: str) -> ModelResponse:
+    return ModelResponse(parts=[TextPart(content=content)])
+
+
+def _tool_call() -> ModelResponse:
+    return ModelResponse(parts=[ToolCallPart(tool_name="t", args={}, tool_call_id="c1")])
+
+
+def _tool_return() -> ModelRequest:
+    return ModelRequest(parts=[ToolReturnPart(tool_name="t", content="r", tool_call_id="c1")])
 
 
 def test_create_session_id_format():
@@ -36,3 +65,41 @@ def test_jsonl_session_store_missing_session_returns_empty(tmp_path: Path):
     init_workspace(tmp_path)
     store = JsonlSessionStore(tmp_path)
     assert list(store.iter_messages("does-not-exist")) == [], f"Expected iter_messages for non-existent session to return empty list, but got: {list(store.iter_messages('does-not-exist'))}"
+
+
+def test_trim_under_limit_returns_history_unchanged():
+    messages = [_user("u1"), _assistant("a1")]
+    assert trim_message_history(messages, max_messages=40) is messages
+
+
+def test_trim_cuts_at_a_user_turn_boundary():
+    messages = []
+    for i in range(30):
+        messages.append(_user(f"u{i}"))
+        messages.append(_assistant(f"a{i}"))
+
+    trimmed = trim_message_history(messages, max_messages=40)
+
+    assert len(trimmed) <= 40
+    first = trimmed[0]
+    assert isinstance(first, ModelRequest)
+    assert any(isinstance(part, UserPromptPart) for part in first.parts)
+
+
+def test_trim_never_starts_mid_tool_exchange():
+    messages = [
+        _user("u1"), _tool_call(), _tool_return(), _assistant("a1"),
+        _user("u2"), _tool_call(), _tool_return(), _assistant("a2"),
+    ]
+
+    # A naive messages[-6:] slice would start at the tool-return request;
+    # the trim must skip forward to the next user turn instead.
+    trimmed = trim_message_history(messages, max_messages=6)
+
+    assert trimmed[0] is messages[4]
+    assert len(trimmed) == 4
+
+
+def test_trim_without_user_boundary_returns_history_unchanged():
+    messages = [_assistant(f"a{i}") for i in range(10)]
+    assert trim_message_history(messages, max_messages=4) is messages

--- a/tests/integration/test_sqlite_memory.py
+++ b/tests/integration/test_sqlite_memory.py
@@ -2,7 +2,9 @@
 
 from pathlib import Path
 
-from miminions.memory.sqlite import SQLiteMemory
+import pytest
+
+from miminions.memory.sqlite import SQLiteMemory, sqlite3
 from miminions.memory.sqlite import get_global_memory_db_path
 from miminions.agent import create_minion
 from miminions.tools.schemas import ExecutionStatus
@@ -115,6 +117,33 @@ def test_execution_timing():
     
     memory.close()
     print("PASSED")
+
+
+def test_context_manager_closes_connection():
+    """`with SQLiteMemory(...)` should work inside the block and close on exit."""
+    with SQLiteMemory(db_path=":memory:") as memory:
+        entry_id = memory.create("Context managers are neat", metadata={"source": "test"})
+        assert memory.get_by_id(entry_id)["text"] == "Context managers are neat"
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        memory.conn.execute("SELECT 1")
+
+
+def test_context_manager_propagates_exceptions():
+    """Exceptions inside the block must not be suppressed, and still close."""
+    with pytest.raises(ValueError, match="boom"):
+        with SQLiteMemory(db_path=":memory:") as memory:
+            raise ValueError("boom")
+
+    with pytest.raises(sqlite3.ProgrammingError):
+        memory.conn.execute("SELECT 1")
+
+
+def test_double_close_is_noop():
+    """Calling close() twice (e.g. explicit close + __exit__) must not raise."""
+    memory = SQLiteMemory(db_path=":memory:")
+    memory.close()
+    memory.close()
 
 
 def test_get_global_memory_db_path_uses_home(monkeypatch, tmp_path):

--- a/tests/unit/test_minion_hooks.py
+++ b/tests/unit/test_minion_hooks.py
@@ -1,0 +1,60 @@
+"""Unit tests for Minion observability hooks (on_tool_call / on_turn_end)."""
+
+from pydantic_ai.models.test import TestModel
+
+from miminions.agent import create_minion
+
+
+def _echo(text: str) -> str:
+    """Echo tool used to trigger a controlled tool call."""
+    return text
+
+
+def _make_minion(**kwargs):
+    # call_tools must stay restricted to the harmless echo tool: TestModel
+    # invokes every listed tool, and Minion always registers cli_run_command,
+    # which executes a real shell command.
+    minion = create_minion(name="Hooks", model=TestModel(call_tools=["echo"]), **kwargs)
+    minion.register_tool("echo", "Echo text back", _echo)
+    return minion
+
+
+async def test_on_tool_call_fires_with_name_and_args():
+    calls = []
+    minion = _make_minion(on_tool_call=lambda name, args: calls.append((name, args)))
+
+    await minion.run("use the echo tool")
+
+    assert calls, "expected at least one tool-call event"
+    name, args = calls[0]
+    assert name == "echo"
+    assert "text" in args
+
+
+async def test_on_turn_end_receives_usage_and_latency():
+    turns = []
+    minion = _make_minion(on_turn_end=lambda usage, latency: turns.append((usage, latency)))
+
+    await minion.run("hello")
+
+    assert len(turns) == 1
+    usage, latency = turns[0]
+    assert usage.requests >= 1
+    assert latency >= 0
+
+
+async def test_raising_callbacks_do_not_break_the_turn():
+    def _boom(*_args):
+        raise RuntimeError("callback exploded")
+
+    minion = _make_minion(on_tool_call=_boom, on_turn_end=_boom)
+
+    reply = await minion.run("hello")
+
+    assert isinstance(reply, str)
+
+
+def test_handler_is_none_without_callback():
+    minion = _make_minion()
+
+    assert minion._make_event_stream_handler() is None

--- a/tests/unit/test_minion_retry.py
+++ b/tests/unit/test_minion_retry.py
@@ -1,0 +1,151 @@
+"""Unit tests for retry/timeout handling around Minion model calls."""
+
+import pytest
+from pydantic_ai.exceptions import ModelAPIError, ModelHTTPError
+from pydantic_ai.models.test import TestModel
+
+from miminions.agent.agent import Minion, _is_retryable_error
+
+
+def _http_error(status_code: int) -> ModelHTTPError:
+    return ModelHTTPError(status_code=status_code, model_name="test-model")
+
+
+class _FakeResult:
+    output = "ok"
+    usage = None
+
+    def all_messages(self):
+        return ["message"]
+
+
+class _FlakyAgent:
+    """Stub pydantic_ai Agent whose run() fails N times before succeeding."""
+
+    def __init__(self, failures):
+        self._failures = list(failures)
+        self.calls = 0
+
+    async def run(self, *args, **kwargs):
+        self.calls += 1
+        if self._failures:
+            raise self._failures.pop(0)
+        return _FakeResult()
+
+
+def _make_minion(**kwargs) -> Minion:
+    return Minion(name="Retry", model=TestModel(), retry_base_delay=0, **kwargs)
+
+
+def _stub_agent(minion: Minion, fake: _FlakyAgent, monkeypatch) -> None:
+    monkeypatch.setattr(minion, "_rebuild_pydantic_ai_agent", lambda: None)
+    minion._pydantic_ai_agent = fake
+
+
+async def test_transient_errors_are_retried_then_succeed(monkeypatch):
+    minion = _make_minion()
+    fake = _FlakyAgent([_http_error(429), _http_error(500)])
+    _stub_agent(minion, fake, monkeypatch)
+
+    reply = await minion.run("hello")
+
+    assert reply == "ok"
+    assert fake.calls == 3
+    assert minion._last_messages == ["message"]
+
+
+async def test_non_retryable_error_raises_immediately(monkeypatch):
+    minion = _make_minion()
+    fake = _FlakyAgent([_http_error(401)])
+    _stub_agent(minion, fake, monkeypatch)
+
+    with pytest.raises(ModelHTTPError):
+        await minion.run("hello")
+
+    assert fake.calls == 1
+
+
+async def test_exhausted_retries_reraise(monkeypatch):
+    minion = _make_minion(max_retries=1)
+    fake = _FlakyAgent([_http_error(503), _http_error(503)])
+    _stub_agent(minion, fake, monkeypatch)
+
+    with pytest.raises(ModelHTTPError):
+        await minion.run("hello")
+
+    assert fake.calls == 2
+
+
+async def test_connection_errors_are_retried(monkeypatch):
+    minion = _make_minion()
+    fake = _FlakyAgent([ModelAPIError("test-model", "connection reset")])
+    _stub_agent(minion, fake, monkeypatch)
+
+    reply = await minion.run("hello")
+
+    assert reply == "ok"
+    assert fake.calls == 2
+
+
+async def test_backoff_delays_double_per_attempt(monkeypatch):
+    minion = Minion(name="Backoff", model=TestModel(), retry_base_delay=0.5)
+    fake = _FlakyAgent([_http_error(429), _http_error(500)])
+    _stub_agent(minion, fake, monkeypatch)
+
+    delays = []
+
+    async def _record_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr("miminions.agent.agent.asyncio.sleep", _record_sleep)
+
+    reply = await minion.run("hello")
+
+    assert reply == "ok"
+    assert delays == [0.5, 1.0]
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (_http_error(429), True),
+        (_http_error(500), True),
+        (_http_error(503), True),
+        (_http_error(400), False),
+        (_http_error(401), False),
+        (ModelAPIError("test-model", "boom"), True),
+        (ValueError("boom"), False),
+    ],
+)
+def test_is_retryable_error(exc, expected):
+    assert _is_retryable_error(exc) is expected
+
+
+def test_rebuild_passes_request_timeout(monkeypatch):
+    captured = {}
+
+    class _CapturingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("miminions.agent.agent.Agent", _CapturingAgent)
+    minion = Minion(name="Timeout", model=TestModel(), request_timeout=12.5)
+
+    minion._rebuild_pydantic_ai_agent()
+
+    assert captured["model_settings"] == {"timeout": 12.5}
+
+
+def test_rebuild_omits_model_settings_without_timeout(monkeypatch):
+    captured = {}
+
+    class _CapturingAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+    monkeypatch.setattr("miminions.agent.agent.Agent", _CapturingAgent)
+    minion = Minion(name="NoTimeout", model=TestModel(), request_timeout=None)
+
+    minion._rebuild_pydantic_ai_agent()
+
+    assert captured["model_settings"] is None

--- a/tests/unit/test_minion_stream.py
+++ b/tests/unit/test_minion_stream.py
@@ -1,0 +1,54 @@
+"""Unit tests for Minion.run_stream()."""
+
+import pytest
+from pydantic_ai.exceptions import ModelHTTPError
+from pydantic_ai.models.test import TestModel
+
+from miminions.agent import create_minion
+
+
+async def test_stream_yields_deltas_and_updates_history():
+    minion = create_minion(
+        name="Stream",
+        model=TestModel(custom_output_text="hello world", call_tools=[]),
+    )
+
+    deltas = [delta async for delta in minion.run_stream("hi")]
+
+    assert "".join(deltas) == "hello world"
+    assert minion._last_messages
+
+
+async def test_stream_fires_on_turn_end():
+    turns = []
+    minion = create_minion(
+        name="Stream",
+        model=TestModel(call_tools=[]),
+        on_turn_end=lambda usage, latency: turns.append((usage, latency)),
+    )
+
+    async for _ in minion.run_stream("hi"):
+        pass
+
+    assert len(turns) == 1
+    usage, latency = turns[0]
+    assert usage.requests >= 1
+    assert latency >= 0
+
+
+async def test_stream_error_propagates_and_history_unchanged(monkeypatch):
+    minion = create_minion(name="Stream", model=TestModel())
+
+    class _BoomAgent:
+        def run_stream(self, *args, **kwargs):
+            raise ModelHTTPError(status_code=500, model_name="test-model")
+
+    monkeypatch.setattr(minion, "_rebuild_pydantic_ai_agent", lambda: None)
+    minion._pydantic_ai_agent = _BoomAgent()
+    minion._last_messages = ["sentinel"]
+
+    with pytest.raises(ModelHTTPError):
+        async for _ in minion.run_stream("hi"):
+            pass
+
+    assert minion._last_messages == ["sentinel"]

--- a/tests/unit/test_workspace_loading.py
+++ b/tests/unit/test_workspace_loading.py
@@ -1,8 +1,13 @@
 """Tests for resilient, non-silent workspace loading."""
 
+import json
 import logging
 
-from miminions.core.workspace import WorkspaceManager
+from miminions.core.workspace import (
+    WORKSPACE_SCHEMA_VERSION,
+    Workspace,
+    WorkspaceManager,
+)
 
 
 def test_corrupt_workspaces_file_returns_empty_and_warns(tmp_path, caplog):
@@ -26,3 +31,65 @@ def test_missing_workspaces_file_returns_empty_silently(tmp_path, caplog):
 
     assert result == {}
     assert not caplog.records
+
+
+def test_to_dict_stamps_current_schema_version():
+    """Every persisted record must carry the current schema version."""
+    workspace = Workspace(name="Stamped")
+
+    assert workspace.to_dict()["schema_version"] == WORKSPACE_SCHEMA_VERSION
+
+
+def test_legacy_record_without_schema_version_loads_silently(tmp_path, caplog):
+    """Records saved before versioning existed are treated as v1 — no warning."""
+    legacy = {"ws1": {"id": "ws1", "name": "Legacy", "description": ""}}
+    (tmp_path / "workspaces.json").write_text(json.dumps(legacy))
+    manager = WorkspaceManager(tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        result = manager.load_workspaces()
+
+    assert result["ws1"].name == "Legacy"
+    assert not caplog.records
+
+
+def test_save_stamps_schema_version_and_leaves_no_tmp_file(tmp_path):
+    """save_workspaces writes the version stamp via an atomic replace."""
+    manager = WorkspaceManager(tmp_path)
+    workspace = Workspace(name="Stamped")
+
+    manager.save_workspaces({workspace.id: workspace})
+
+    raw = json.loads((tmp_path / "workspaces.json").read_text())
+    assert raw[workspace.id]["schema_version"] == WORKSPACE_SCHEMA_VERSION
+    assert not (tmp_path / "workspaces.tmp").exists()
+
+
+def test_invalid_schema_version_warns_but_does_not_discard_file(tmp_path, caplog):
+    """One tampered record must not take down the other workspaces in the file."""
+    records = {
+        "bad": {"schema_version": None, "id": "bad", "name": "Tampered"},
+        "good": {"schema_version": 1, "id": "good", "name": "Fine"},
+    }
+    (tmp_path / "workspaces.json").write_text(json.dumps(records))
+    manager = WorkspaceManager(tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        result = manager.load_workspaces()
+
+    assert result["bad"].name == "Tampered"
+    assert result["good"].name == "Fine"
+    assert any("invalid schema_version" in r.message for r in caplog.records)
+
+
+def test_newer_schema_version_warns_but_loads(tmp_path, caplog):
+    """A record from a future format version loads best-effort with a warning."""
+    record = {"ws1": {"schema_version": 99, "id": "ws1", "name": "Future"}}
+    (tmp_path / "workspaces.json").write_text(json.dumps(record))
+    manager = WorkspaceManager(tmp_path)
+
+    with caplog.at_level(logging.WARNING):
+        result = manager.load_workspaces()
+
+    assert result["ws1"].name == "Future"
+    assert any("schema_version" in r.message for r in caplog.records)


### PR DESCRIPTION
## Description

Implements all six runtime items from issue #88 section 7: retry/timeout around
model calls, context window management, streaming chat output, observability
hooks, workspace schema versioning, and SQLite connection lifecycle.

Part of #88 (does not close it — other sections are owned separately)

## What changed

**Retry/timeout around model calls**
- `Minion` gained `request_timeout` (default 60s per HTTP request), `max_retries`
  (default 2) and `retry_base_delay`. Transient provider errors (HTTP 429/5xx,
  connection failures, timeouts) retry with exponential backoff; auth and other
  4xx errors still fail immediately.

**Streaming output in chat**
- New `Minion.run_stream()` yields the reply as text deltas; `chat start` now
  prints them as they arrive instead of waiting for the full completion.
  If a stream fails mid-turn, the partial reply is persisted with an error
  marker so the transcript matches what was shown on screen.

**Context window management**
- Chat history sent to the model is capped at the newest 40 messages
  (`trim_message_history`), cutting only at user-turn boundaries so resumed
  sessions never start mid-tool-exchange. The on-disk JSONL transcript stays
  complete; long-term recall remains the distiller's job.

**Observability hooks + `--verbose`**
- Optional `on_tool_call(name, args)` and `on_turn_end(usage, latency)`
  callbacks on `Minion`. `chat start --verbose` prints tool calls, token
  usage and per-turn latency to stderr.

**Workspace schema versioning + atomic save**
- Every saved workspace record carries `"schema_version": 1`; a migration hook
  on load treats legacy records as v1, warns on newer/corrupt versions, and is
  the single place future format migrations go. `save_workspaces()` now writes
  atomically via the shared `save_json` helper.

**SQLiteMemory connection lifecycle**
- `SQLiteMemory` supports `with SQLiteMemory(...) as mem:`; the distiller and
  context builder use it instead of manual `try/finally: close()`.

## Why the changes are needed

These are the agent-framework gaps from issue #88 §7: one transient provider
error killed a whole turn, session history grew unbounded into the context,
replies only appeared after the full completion, there was no visibility into
tool calls or token usage, workspace records had no version marker for future
format changes, and DB connections relied on nondeterministic `__del__` cleanup.

## How to validate the changes

`miminions chat start --verbose` — replies stream incrementally, with
`[tool]`/`[turn]` diagnostics on stderr. Existing sessions and `workspaces.json`
files load unchanged.

## Testing

- `pytest tests/unit tests/integration` — 475 passed, no regressions.
- 35 new tests across retry classification/backoff, timeout plumbing, hook
  firing and error isolation, streaming deltas and mid-stream failure,
  history-trim boundary cases, schema-version load/save/migration, and the
  SQLiteMemory context manager.
- `ruff check` clean on all changed files (4 repo lint errors are pre-existing
  in untouched files); mypy introduces no new issues beyond one pre-existing
  false-positive pattern.
